### PR TITLE
fix: Add statement to SecOps SNS topic policy allowing the Tamper Detection module to publish alerts and prettify the message

### DIFF
--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -218,12 +218,12 @@ resource "aws_sns_topic_policy" "secops" {
         }
       },
       {
-        Sid = "AllowEventBridgeTamperDetectionAlerts"
+        Sid    = "AllowEventBridgeTamperDetectionAlerts"
         Effect = "Allow"
         Principal = {
           Service = "events.amazonaws.com"
         }
-        Action = "sns:Publish"
+        Action   = "sns:Publish"
         Resource = aws_sns_topic.secops.arn
         Condition = {
           StringEquals = {

--- a/modules/security/tamper_detection/main.tf
+++ b/modules/security/tamper_detection/main.tf
@@ -63,14 +63,14 @@ resource "aws_cloudwatch_event_target" "tamper_to_sns" {
 
   input_transformer {
     input_paths = {
-      time        = "$.time"
-      account     = "$.account"
-      region      = "$.region"
-      event_name  = "$.detail.eventName"
-      event_src   = "$.detail.eventSource"
-      actor       = "$.detail.userIdentity.arn"
-      source_ip   = "$.detail.sourceIPAddress"
-      mfa         = "$.detail.userIdentity.sessionContext.attributes.mfaAuthenticated"
+      time       = "$.time"
+      account    = "$.account"
+      region     = "$.region"
+      event_name = "$.detail.eventName"
+      event_src  = "$.detail.eventSource"
+      actor      = "$.detail.userIdentity.arn"
+      source_ip  = "$.detail.sourceIPAddress"
+      mfa        = "$.detail.userIdentity.sessionContext.attributes.mfaAuthenticated"
     }
 
     input_template = <<EOT


### PR DESCRIPTION
This PR addresses the following issues:

Add policy statements to SecOps SNS policy to allow 'aws_cloudwatch_event_rule.tamper_to_sns'' #163 
Prettify the SNS notification sent after tamper detection rule triggers #166 