### PR TITLE
docs: rewrite the 'docs/lambda_tests/ec2_isolation.md' file to reference SSO

### DIFF
--- a/docs/lambda_tests/ec2_rollback.md
+++ b/docs/lambda_tests/ec2_rollback.md
@@ -174,11 +174,12 @@ This test requires a locally-configured AWS CLI SSO profile.
 
 #### Manual Event from AWS CLI
 
-Run the following from a terminal authenticated with the `SecOps-Operator` SSO profile:
 > Ensure the AWS CLI is configured for the same region as the deployed infrastrustructure (`us-east-1`) by running the following:
 > ```bash
 > aws configure get region --profile <profile-name>
 > ```
+
+Run the following from a terminal authenticated with the `SecOps-Operator` SSO profile:
 
 ```bash
 aws events put-events --region us-east-1 --entries '[


### PR DESCRIPTION
This PR addresses the following issue:

Update docs/lambda_tests/ec2_isolation.md file #156 