### PR TITLE
ci: add bash script to 'Terraform Apply' job to retry the 'terraform …

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -62,7 +62,7 @@ jobs:
                 terraform apply -auto-approve -input=false -no-color 2>&1 | tee apply.log
                 status=$?
 
-                if [$status -ne 0] && grep -q "Permission set provision not found" apply.log; then
+                if [ $status -ne 0 ] && grep -q "Permission set provision not found|Assignment not found" apply.log; then
                     echo "Hit IAM Identity Center provisioning consistency issue. Retrying once..."
                     sleep 30
                     terraform apply -auto-approve -input=false -no-color


### PR DESCRIPTION
…apply' command if it hits the Identity Center (SSO) error that results because Terraform and AWS are 'eventually consistent'

This PR addresses the following issue: 

Configure 'Terraform Apply' job to run a follow up 'terraform apply' if Identity Center errors #187 