### PR TITLE
ci: robustify 'Terraform Apply' job when SSO eventual consistency issue occurs

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -70,7 +70,7 @@ jobs:
                         exit 0
                     fi
 
-                    if [ $status -ne 0 ] && grep -Eq "Permission set provision not found|Assignment not found" apply.log; then
+                    if grep -Eq "Permission set provision not found|Assignment not found" apply.log; then
                         if [ $attempt -lt 3 ]; then
                             echo "Hit IAM Identity Center eventual consistency issue. Retrying on attempt $attempt. Retrying in 45 seconds..."
                             sleep 45


### PR DESCRIPTION
This PR addresses the following issues:

Make the 'Terraform Apply' retry more robust in case SSO fails twice #189 