### PR TITLE
ci: add references to the 'baseline' stack's new location for each job

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -51,12 +51,15 @@ jobs:
               uses: hashicorp/setup-terraform@v3
 
             - name: Terraform Init
+              working-directory: ./baseline
               run: terraform init
 
             - name: Terraform Validate
+              working-directory: ./baseline
               run: terraform validate
 
             - name: Terraform Apply
+              working-directory: ./baseline
               shell: bash
               run: |
                 set -o pipefail

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -55,9 +55,15 @@ jobs:
               uses: hashicorp/setup-terraform@v3
 
             - name: Terraform Init
+              working-directory: ./baseline
               run: terraform init
 
+            - name: Terraform Validate
+              working-directory: ./baseline
+              run: terraform validate
+
             - name: Terraform Destroy
+              working-directory: ./baseline
               shell: bash
               run: |
                 set -o pipefail

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -33,12 +33,15 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
+        working-directory: ./baseline
         run: terraform init
 
       - name: Terraform Validate
+        working-directory: ./baseline
         run: terraform validate
 
       - name: Terraform Plan
+        working-directory: ./baseline
         run: terraform plan -no-color
         env:
             TF_VAR_abuseipdb_api_key: ${{secrets.ABUSEIPDB_API_KEY}}


### PR DESCRIPTION
This PR addresses the following issue:

Fix issue where workflows can't find the 'baseline' stack #222 