### PR TITLE
ci: add 'Identity Center Cleanup' job to 'Terraform Destroy' CI/CD workflow

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -38,6 +38,9 @@ jobs:
             TF_VAR_tf_state_lock_table_arn: ${{vars.TF_STATE_LOCK_TABLE_ARN}}
             TF_VAR_break_glass_trusted_principal_arns: ${{vars.BREAK_GLASS_TRUSTED_PRINCIPAL_ARNS}}
             TF_VAR_secops_emails: ${{vars.SECOPS_EMAILS}}
+            TF_VAR_account_id_dev: ${{vars.ACCOUNT_ID_DEV}}
+            TF_VAR_account_id_prod: ${{vars.ACCOUNT_ID_PROD}}
+            TF_VAR_account_id_staging: ${{vars.ACCOUNT_ID_STAGING}}
 
         steps:
             - name: Checkout

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -24,6 +24,27 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    identity-center-cleanup:
+      if: ${{inputs.confirm == 'DESTROY'}}
+      runs-on: ubuntu-latest
+      environment: control-plane
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Configure AWS credentials for Control Plane
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+            role-to-assume: ${{vars.APPLY_ROLE_GITHUB_ARN}}
+            aws-region: ${{vars.PRIMARY_REGION}}
+
+        - name: Setup Terraform
+          uses: hashicorp/setup-terraform@v3
+
+        - name: Terraform Init Identity Center
+          working-directory: ./bootstrap/control_plane/identity_center
+          run: terraform init
     terraform-destroy:
         if: ${{inputs.confirm == 'DESTROY'}}
         runs-on: ubuntu-latest

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -66,6 +66,7 @@ jobs:
             terraform apply -auto-approve -input=false -no-color
 
     terraform-destroy:
+        needs: identity-center-cleanup
         if: ${{inputs.confirm == 'DESTROY'}}
         runs-on: ubuntu-latest
         environment: ${{inputs.environment}}
@@ -110,5 +111,5 @@ jobs:
               working-directory: ./environments/${{inputs.environment}}
               shell: bash
               run: |
-                set -o pipefail
+                set -euo pipefail
                 terraform destroy -auto-approve -input=false -no-color

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -34,6 +34,9 @@ jobs:
         TF_VAR_tf_state_bucket_arn: ${{vars.TF_STATE_BUCKET_ARN}}
         TF_VAR_tf_state_bucket_cmk_arn: ${{vars.TF_STATE_BUCKET_CMK_ARN}}
         TF_VAR_tf_state_lock_table_arn: ${{vars.TF_STATE_LOCK_TABLE_ARN}}
+        TF_VAR_account_id_dev: ${{vars.ACCOUNT_ID_DEV}}
+        TF_VAR_account_id_prod: ${{vars.ACCOUNT_ID_PROD}}
+        TF_VAR_account_id_staging: ${{vars.ACCOUNT_ID_STAGING}}
 
       steps:
         - name: Checkout

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -29,6 +29,12 @@ jobs:
       runs-on: ubuntu-latest
       environment: control-plane
 
+      env:
+        TF_VAR_bucket_admin_principals: ${{vars.BUCKET_ADMIN_PRINCIPALS}}
+        TF_VAR_tf_state_bucket_arn: ${{vars.TF_STATE_BUCKET_ARN}}
+        TF_VAR_tf_state_bucket_cmk_arn: ${{vars.TF_STATE_BUCKET_CMK_ARN}}
+        TF_VAR_tf_state_lock_table_arn: ${{vars.TF_STATE_LOCK_TABLE_ARN}}
+
       steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -45,6 +45,20 @@ jobs:
         - name: Terraform Init Identity Center
           working-directory: ./bootstrap/control_plane/identity_center
           run: terraform init
+
+        - name: Identity Center Cleanup
+          working-directory: ./bootstrap/control_plane/identity_center
+          shell: bash
+          run: |
+            set -euo pipefail
+
+            export TF_VAR_enable_secops_analyst_${{ inputs.environment }}=false
+            export TF_VAR_enable_secops_engineer_${{ inputs.environment }}=false
+            export TF_VAR_logs_s3_readonly_policy_name_${{ inputs.environment }}=""
+            export TF_VAR_logs_cmk_decrypt_policy_name_${{ inputs.environment }}=""
+
+            terraform apply -auto-approve -input=false -no-color
+
     terraform-destroy:
         if: ${{inputs.confirm == 'DESTROY'}}
         runs-on: ubuntu-latest

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -37,7 +37,7 @@ jobs:
 
     concurrency:
       group: terraform-plan-${{github.head_ref || github.ref_name}}-${{matrix.environment}}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     environment: ${{matrix.github_environment}}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -65,5 +65,5 @@ jobs:
         run: terraform validate
 
       - name: Terraform Plan
-        working-directory: ./environments/${{matrix.environment}}
+        working-directory: ${{matrix.working_directory}}
         run: terraform plan -no-color

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -39,7 +39,7 @@ jobs:
       group: terraform-plan-${{github.head_ref || github.ref_name}}-${{matrix.environment}}
       cancel-in-progress: true
 
-    environment: ${{format('{0}-plan', matrix.environment)}}
+    environment: ${{matrix.github_environment}}
 
     env:
         TF_VAR_abuseipdb_api_key: ${{secrets.ABUSEIPDB_API_KEY}}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [dev, staging, prod]
+        environment: [dev, staging, prod, control-plane]
       
     concurrency:
       group: terraform-plan-${{github.head_ref || github.ref_name}}-${{matrix.environment}}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -15,8 +15,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [dev, staging, prod, control-plane]
-      
+        include:
+          - environment: dev
+            working_directory: ./environments/dev
+          - environment: prod
+            working_directory: ./environments/prod
+          - environment: staging
+            working_directory: ./environments/staging
+          - environment: control-plane
+            working_directory: ./bootstrap/control_plane/account
+
     concurrency:
       group: terraform-plan-${{github.head_ref || github.ref_name}}-${{matrix.environment}}
       cancel-in-progress: true
@@ -49,7 +57,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        working-directory: ./environments/${{matrix.environment}}
+        working-directory: ${{matrix.working_directory}}
         run: terraform init
 
       - name: Terraform Validate

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -17,13 +17,23 @@ jobs:
       matrix:
         include:
           - environment: dev
+            github_environment: dev-plan
             working_directory: ./environments/dev
           - environment: prod
+            github_environment: prod-plan
             working_directory: ./environments/prod
           - environment: staging
+            github_environment: staging-plan
             working_directory: ./environments/staging
-          - environment: control-plane
+          - environment: control-plane-account
+            github_environment: control-plane-plan
             working_directory: ./bootstrap/control_plane/account
+          - environment: control-plane-identity-center
+            github_environment: control-plane-plan
+            working_directory: ./bootstrap/control_plane/identity_center
+          - environment: control-plane-organizations
+            github_environment: control-plane-plan
+            working_directory: ./bootstrap/control_plane/organizations
 
     concurrency:
       group: terraform-plan-${{github.head_ref || github.ref_name}}-${{matrix.environment}}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -76,4 +76,4 @@ jobs:
 
       - name: Terraform Plan
         working-directory: ${{matrix.working_directory}}
-        run: terraform plan -no-color
+        run: terraform plan -no-color -lock-timeout=5m

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -61,7 +61,7 @@ jobs:
         run: terraform init
 
       - name: Terraform Validate
-        working-directory: ./environments/${{matrix.environment}}
+        working-directory: ${{matrix.working_directory}}
         run: terraform validate
 
       - name: Terraform Plan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,6 +49,9 @@ jobs:
         TF_VAR_tf_state_lock_table_arn: ${{vars.TF_STATE_LOCK_TABLE_ARN}}
         TF_VAR_break_glass_trusted_principal_arns: ${{vars.BREAK_GLASS_TRUSTED_PRINCIPAL_ARNS}}
         TF_VAR_secops_emails: ${{vars.SECOPS_EMAILS}}
+        TF_VAR_account_id_dev: ${{vars.ACCOUNT_ID_DEV}}
+        TF_VAR_account_id_prod: ${{vars.ACCOUNT_ID_PROD}}
+        TF_VAR_account_id_staging: ${{vars.ACCOUNT_ID_STAGING}}
 
     steps:
       - name: Checkout

--- a/bootstrap/control_plane/account/README.md
+++ b/bootstrap/control_plane/account/README.md
@@ -1,0 +1,181 @@
+# Bootstrap Stack
+
+## Overview
+
+This stack provisions the **GitHub OIDC control plane** for the environment.
+
+It deploys:
+
+- GitHub OIDC provider
+- `GitHub-Plan` role
+- `GitHub-Apply` role
+
+This stack is intentionally separated from the main Terraform baseline to prevent self-destruction during CI/CD operations.
+
+---
+
+## Why This Exists
+
+Without this separation:
+
+- The `Terraform Destroy` CI/CD workflow can remove the IAM roles it is actively using
+- This results in:
+  - Failed applies
+  - Corrupted state
+  - Broken pipelines
+
+This stack solves that by isolating execution-plane resources.
+
+---
+
+## Architecture
+
+`state` stack ➔ `bootstrap` and `baseline` stacks
+
+`bootstrap` stack ➔ `github_oidc` module
+
+`baseline` stack ➔ All infrastructure (VPC, Lambda, S3, etc.)
+
+---
+
+## Deployment Order
+
+### Initial Setup
+
+The following steps assume that you have already deployed the `state` stack (refer to the `/state/README.md` file):
+
+1. Deploy `bootstrap` stack
+
+```bash
+cd bootstrap
+terraform init
+terraform apply
+```
+>Note the `apply_role_github_arn` output
+
+2. Add the `apply_role_github_arn` output's value to the `bucket_admin_principals` variable (defined in `bootstrap` stack)
+
+Example:
+
+```bash
+export TF_VAR_bucket_admin_principals=["arn:aws:iam::<account_id>:root","arn:aws:iam::<account_id>:role/tf-secure-baseline-dev-github-apply-role"]
+```
+
+3. Deploy `baseline` stack after setting required variables (locally once)
+
+```bash
+cd ../baseline
+terraform apply
+```
+> Note the `lambda_cmk_arn` and `secrets_manager_cmk_arn` outputs
+
+4. Define the `lambda_cmk_arn` and `secrets_manager_cmk_arn` variables
+
+```bash
+TF_VAR_lambda_cmk_arn="<lambda_cmk_arn>"
+TF_VAR_secrets_manager_cmk_arn="<secrets_manager_cmk-arn"
+```
+
+5. Re-apply `bootstrap` stack
+
+```bash
+cd ../bootstrap
+terraform apply
+```
+
+## Usage
+
+```hcl
+module "github_oidc" {
+  source = "../modules/github_oidc"
+
+  name_prefix    = var.name_prefix
+  primary_region = var.primary_region
+  account_id     = var.account_id
+
+  owner_github = var.owner_github
+  repo_github  = var.repo_github
+
+  tf_state_bucket_arn     = var.tf_state_bucket_arn
+  tf_state_bucket_cmk_arn = var.tf_state_bucket_cmk_arn
+
+  lambda_cmk_arn          = var.lambda_cmk_arn
+  secrets_manager_cmk_arn = var.secrets_manager_cmk_arn
+
+  enable_apply_role_github = var.enable_apply_role_github
+}
+```
+
+## Inputs
+
+| Name | Description |
+|------|-------------|
+| `name_prefix` | Resource naming prefix |
+| `primary_region` | AWS region |
+| `account_id` | AWS account ID |
+| `owner_github` | GitHub org/user |
+| `repo_github` | GitHub repo |
+| `tf_state_bucket_arn` | Terraform state bucket |
+| `tf_state_bucket_cmk_arn` | CMK for state bucket |
+| `lambda_cmk_arn` | Lambda CMK (optional on first apply) |
+| `secrets_manager_cmk_arn` | Secrets CMK (optional on first apply) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `plan_role_github_arn` | `GitHub-Plan` role ARN |
+| `apply_role_github_arn` | `GitHub-Apply` role ARN |
+
+---
+
+## Important Notes
+
+- This stack should **NOT** be destroyed during normal operations
+- It is safe to keep this deployed permanently
+- Destroy workflows should only target the **baseline stack**
+
+---
+
+## CI/CD Behavior
+
+- GitHub Actions assumes roles created here
+- Baseline workflows depend on this stack
+- Destroy workflow does **not** affect this stack
+
+---
+
+## State Management
+
+This stack uses a **separate state** from the baseline stack.
+
+Example:
+
+```
+bootstrap state: tf-state-bootstrap
+baseline state: tf-state
+```
+
+---
+
+## When to Modify
+
+Only update this stack when:
+
+- Changing GitHub repo/org
+- Modifying role permissions
+- Updating trust conditions
+
+---
+
+## When NOT to Modify
+
+Do not modify during normal infra changes.
+
+---
+
+## Summary
+
+This stack represents the execution plane for Terraform.
+
+It must remain stable and separate from the infrastructure it manages.

--- a/bootstrap/control_plane/account/backend.tf
+++ b/bootstrap/control_plane/account/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "tf-secure-baseline-dev-state"
+    key            = "bootstrap/dev.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "tf-secure-baseline-dev-lock"
+    use_lockfile   = true
+  }
+}

--- a/bootstrap/control_plane/account/backend.tf
+++ b/bootstrap/control_plane/account/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket         = "tf-secure-baseline-bootstrap-state"
-    key            = "control-plane/bootstrap.tfstate"
+    key            = "control-plane/account.tfstate"
     region         = "us-east-1"
     encrypt        = true
     dynamodb_table = "tf-secure-baseline-bootstrap-lock"

--- a/bootstrap/control_plane/account/backend.tf
+++ b/bootstrap/control_plane/account/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "tf-secure-baseline-bootstrap-state"
+    bucket         = "tf-secure-baseline-control-plane-state"
     key            = "control-plane/account.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/bootstrap/control_plane/account/backend.tf
+++ b/bootstrap/control_plane/account/backend.tf
@@ -4,7 +4,7 @@ terraform {
     key            = "control-plane/account.tfstate"
     region         = "us-east-1"
     encrypt        = true
-    dynamodb_table = "tf-secure-baseline-bootstrap-lock"
+    dynamodb_table = "tf-secure-baseline-control-plane-lock"
     use_lockfile   = true
   }
 }

--- a/bootstrap/control_plane/account/backend.tf
+++ b/bootstrap/control_plane/account/backend.tf
@@ -1,10 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "tf-secure-baseline-dev-state"
-    key            = "bootstrap/dev.tfstate"
+    bucket         = "tf-secure-baseline-bootstrap-state"
+    key            = "control-plane/bootstrap.tfstate"
     region         = "us-east-1"
     encrypt        = true
-    dynamodb_table = "tf-secure-baseline-dev-lock"
+    dynamodb_table = "tf-secure-baseline-bootstrap-lock"
     use_lockfile   = true
   }
 }

--- a/bootstrap/control_plane/account/main.tf
+++ b/bootstrap/control_plane/account/main.tf
@@ -1,0 +1,29 @@
+locals {
+  name_prefix = "${var.cloud_name}-${var.environment}"
+}
+
+# GLOBAL RESOURCES
+data "aws_caller_identity" "current" {}
+
+module "github_oidc" {
+  source = "../../../modules/github_oidc"
+  count  = var.enable_github_oidc ? 1 : 0
+
+  cloud_name                      = var.cloud_name
+  environment                     = var.environment
+  owner_github                    = var.owner_github
+  repo_github                     = var.repo_github
+  branches_plan_github            = var.branches_plan_github
+  allow_pull_requests_plan_github = var.allow_pull_requests_plan_github
+  name_prefix                     = local.name_prefix
+  tf_state_bucket_arn             = var.tf_state_bucket_arn
+  tf_state_bucket_cmk_arn         = var.tf_state_bucket_cmk_arn
+  tf_state_lock_table_arn         = var.tf_state_lock_table_arn
+  primary_region                  = var.primary_region
+  account_id                      = data.aws_caller_identity.current.account_id
+  enable_apply_role_github        = var.enable_apply_role_github
+  branches_apply_github           = var.branches_apply_github
+  environment_apply_github        = var.environment_apply_github
+  lambda_cmk_arn                  = var.lambda_cmk_arn
+  secrets_manager_cmk_arn         = var.secrets_manager_cmk_arn
+}

--- a/bootstrap/control_plane/account/outputs.tf
+++ b/bootstrap/control_plane/account/outputs.tf
@@ -1,0 +1,9 @@
+output "plan_role_github_arn" {
+  description = "ARN of the GitHub OIDC Terraform plan role"
+  value       = try(module.github_oidc[0].plan_role_github_arn, null)
+}
+
+output "apply_role_github_arn" {
+  description = "ARN of the GitHub OIDC Terraform apply role"
+  value       = try(module.github_oidc[0].apply_role_github_arn, null)
+}

--- a/bootstrap/control_plane/account/providers.tf
+++ b/bootstrap/control_plane/account/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=1.13.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.40.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.primary_region
+}

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -1,5 +1,5 @@
 cloud_name     = "tf-secure-baseline"
-environment    = "dev"
+environment    = "bootstrap"
 primary_region = "us-east-1"
 
 # GitHub-Plan Role-related variables

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -1,0 +1,9 @@
+cloud_name     = "tf-secure-baseline"
+environment    = "dev"
+primary_region = "us-east-1"
+
+# GitHub-Plan Role-related variables
+branches_plan_github = ["main"]
+
+# GitHub-Apply Role-related variables
+branches_apply_github = ["main"]

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -1,5 +1,5 @@
 cloud_name     = "tf-secure-baseline"
-environment    = "bootstrap"
+environment    = "control-plane"
 primary_region = "us-east-1"
 
 # GitHub-Plan Role-related variables

--- a/bootstrap/control_plane/account/variables.tf
+++ b/bootstrap/control_plane/account/variables.tf
@@ -1,0 +1,112 @@
+########################
+# GITHUB OIDC VARIABLES
+########################
+
+variable "cloud_name" {
+  description = "The name of this cloud environment"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "primary_region" {
+  type = string
+}
+
+variable "enable_github_oidc" {
+  description = "Enable GitHub OIDC federation resources for CI/CD"
+  type        = bool
+  default     = false
+}
+
+variable "owner_github" {
+  description = "GitHub organization or username (repo owner)"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_github_oidc || var.owner_github != null
+    error_message = "'owner_github' must be set when 'enable_github_oidc' is 'true'."
+  }
+}
+
+variable "repo_github" {
+  description = "GitHub repository name"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_github_oidc || var.repo_github != null
+    error_message = "'repo_github' must be set when 'enable_github_oidc' is 'true'."
+  }
+}
+
+variable "tf_state_bucket_arn" {
+  description = "ARN of the S3 bucket where the Terraform state is stored"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_github_oidc || var.tf_state_bucket_arn != null
+    error_message = "'tf_state_bucket_arn' must be set when 'enable_github_oidc' is 'true'."
+  }
+}
+
+variable "tf_state_bucket_cmk_arn" {
+  description = "ARN of the KMS CMK used to encrypt the Terraform State bucket"
+  type        = string
+  default     = null
+}
+
+variable "tf_state_lock_table_arn" {
+  description = "ARN of the DynamoDB table used for Terraform state locking"
+  type        = string
+  default     = null
+}
+
+# GitHub-Plan role-related variables
+variable "branches_plan_github" {
+  description = "List of branches allowed to assume the github_oidc role"
+  type        = list(string)
+  default     = ["main"]
+}
+
+variable "allow_pull_requests_plan_github" {
+  description = "Allow pull_request subject in OIDC trust policy"
+  type        = bool
+  default     = false
+}
+
+# GitHub-Apply Role-related variables
+variable "enable_apply_role_github" {
+  description = "Enable the GitHub-Apply role"
+  type        = bool
+  default     = false
+}
+
+variable "branches_apply_github" {
+  description = "Branches allowed to assume the GitHub-Apply role"
+  type        = list(string)
+  default     = ["main"]
+}
+
+variable "environment_apply_github" {
+  description = "GitHub environment allowed to assume the GitHub-Apply role"
+  type        = string
+  default     = null
+}
+
+variable "lambda_cmk_arn" {
+  description = "ARN of the CMK used to encrypt Lambda functions"
+  type        = string
+  default     = null
+}
+
+variable "secrets_manager_cmk_arn" {
+  description = "ARN of the CMK used to encrypt Secrets Manager secrets"
+  type        = string
+  default     = null
+}

--- a/bootstrap/control_plane/identity_center/backend.tf
+++ b/bootstrap/control_plane/identity_center/backend.tf
@@ -4,7 +4,7 @@ terraform {
     key            = "control-plane/identity-center.tfstate"
     region         = "us-east-1"
     encrypt        = true
-    dynamodb_table = "tf-secure-baseline-bootstrap-lock"
+    dynamodb_table = "tf-secure-baseline-control-plane-lock"
     use_lockfile   = true
   }
 }

--- a/bootstrap/control_plane/identity_center/backend.tf
+++ b/bootstrap/control_plane/identity_center/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "tf-secure-baseline-bootstrap-state"
+    bucket         = "tf-secure-baseline-control-plane-state"
     key            = "control-plane/identity-center.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/bootstrap/control_plane/identity_center/main.tf
+++ b/bootstrap/control_plane/identity_center/main.tf
@@ -1,7 +1,3 @@
-locals {
-  name_prefix = "${var.cloud_name}-${var.environment}"
-}
-
 module "identity_center_dev" {
   source = "../../../modules/identity_center"
 

--- a/bootstrap/control_plane/identity_center/terraform.tfvars
+++ b/bootstrap/control_plane/identity_center/terraform.tfvars
@@ -1,5 +1,4 @@
 cloud_name             = "tf-secure-baseline"
-environment            = "bootstrap"
 primary_region_dev     = "us-east-1"
 primary_region_prod    = "us-east-1"
 primary_region_staging = "us-east-1"

--- a/bootstrap/control_plane/identity_center/variables.tf
+++ b/bootstrap/control_plane/identity_center/variables.tf
@@ -81,11 +81,6 @@ variable "secops_engineer_group_name" {
   default     = null
 }
 
-variable "account_id" {
-  description = "ID of the AWS account managing this environment"
-  type        = string
-}
-
 variable "logs_s3_readonly_policy_name_dev" {
   description = "'Name' attribute of the 'dev' env's logs_s3_readonly policy"
   type        = string

--- a/bootstrap/control_plane/identity_center/variables.tf
+++ b/bootstrap/control_plane/identity_center/variables.tf
@@ -3,11 +3,6 @@ variable "cloud_name" {
   type        = string
 }
 
-variable "environment" {
-  description = "Environment name"
-  type        = string
-}
-
 variable "enable_secops_analyst_dev" {
   description = "Determines whether SecOps-Analyst resources are deployed in the 'dev' env"
   type        = bool

--- a/bootstrap/control_plane/organizations/backend.tf
+++ b/bootstrap/control_plane/organizations/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "tf-secure-baseline-bootstrap-state"
+    bucket         = "tf-secure-baseline-control-plane-state"
     key            = "control-plane/organizations.tfstate"
     region         = "us-east-1"
     encrypt        = true

--- a/bootstrap/control_plane/organizations/backend.tf
+++ b/bootstrap/control_plane/organizations/backend.tf
@@ -4,7 +4,7 @@ terraform {
     key            = "control-plane/organizations.tfstate"
     region         = "us-east-1"
     encrypt        = true
-    dynamodb_table = "tf-secure-baseline-bootstrap-lock"
+    dynamodb_table = "tf-secure-baseline-control-plane-lock"
     use_lockfile   = true
   }
 }

--- a/bootstrap/control_plane/state/terraform.tfvars
+++ b/bootstrap/control_plane/state/terraform.tfvars
@@ -1,3 +1,3 @@
 cloud_name     = "tf-secure-baseline"
-environment    = "bootstrap"
+environment    = "control-plane"
 primary_region = "us-east-1"

--- a/modules/identity_center/outputs.tf
+++ b/modules/identity_center/outputs.tf
@@ -6,11 +6,11 @@ output "permission_set_arns" {
     },
 
     var.enable_secops_analyst ? {
-      secops-analyst = aws_ssoadmin_permission_set.secops_analyst.arn
+      secops-analyst = aws_ssoadmin_permission_set.secops_analyst[0].arn
     } : {},
 
     var.enable_secops_engineer ? {
-      secops-engineer = aws_ssoadmin_permission_set.secops_engineer.arn
+      secops-engineer = aws_ssoadmin_permission_set.secops_engineer[0].arn
     } : {}
   )
 }


### PR DESCRIPTION
This MR addresses the following issues:

Fix Terrafrom Plan GitHub CI/CD workflow #275
Create new state bucket for 'control-plane' substack, renaming it from 'bootstrap' to 'control-plane' to reduce confusion #276