### PR TITLE
fix: repair and refine 'Terraform Apply' and 'Terraform Destroy' CI/CD workflows

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -65,10 +65,13 @@ jobs:
             - name: Terraform Validate
               working-directory: ./environments/${{inputs.environment}}
               run: terraform validate
-              
+
             - name: Terraform Plan
               working-directory: ./environments/${{inputs.environment}}
               run: terraform plan -input=false -no-color
+
+            - name: Print apply target
+              run: echo "Applying environment - ${{inputs.environment}}"
 
             - name: Terraform Apply
               working-directory: ./environments/${{inputs.environment}}

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -128,6 +128,9 @@ jobs:
               working-directory: ./environments/${{inputs.environment}}
               run: terraform init
 
+            - name: Print destroy target
+              run: echo "Destroying environment - ${{inputs.environment}}"
+
             - name: Terraform Destroy
               working-directory: ./environments/${{inputs.environment}}
               shell: bash

--- a/.github/workflows/tf-scans.yml
+++ b/.github/workflows/tf-scans.yml
@@ -2,7 +2,7 @@
 ## GIT WORKFLOW FOR CI/CD PIPELINE TERRAFORM SCANS ##
 #####################################################
 
-name: Terraform CI/CD Pipeline
+name: Terraform Scans
 
 permissions:
   contents: read

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -2,9 +2,12 @@ cloud_name     = "tf-secure-baseline"
 environment    = "control-plane"
 primary_region = "us-east-1"
 
+enable_github_oidc = true
+
 # GitHub-Plan Role-related variables
 branches_plan_github = ["main"]
 
 # GitHub-Apply Role-related variables
+enable_apply_role_github = true
 branches_apply_github    = ["main"]
 environment_apply_github = "control-plane"

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -7,3 +7,4 @@ branches_plan_github = ["main"]
 
 # GitHub-Apply Role-related variables
 branches_apply_github = ["main"]
+environment_apply_github = "control-plane"

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -6,5 +6,5 @@ primary_region = "us-east-1"
 branches_plan_github = ["main"]
 
 # GitHub-Apply Role-related variables
-branches_apply_github = ["main"]
+branches_apply_github    = ["main"]
 environment_apply_github = "control-plane"

--- a/bootstrap/control_plane/account/terraform.tfvars
+++ b/bootstrap/control_plane/account/terraform.tfvars
@@ -2,12 +2,9 @@ cloud_name     = "tf-secure-baseline"
 environment    = "control-plane"
 primary_region = "us-east-1"
 
-enable_github_oidc = true
-
 # GitHub-Plan Role-related variables
 branches_plan_github = ["main"]
 
 # GitHub-Apply Role-related variables
-enable_apply_role_github = true
 branches_apply_github    = ["main"]
 environment_apply_github = "control-plane"


### PR DESCRIPTION
This PR address the following issues:

Add a job to the 'Terraform Destroy' workflow to fix the issue where it fails if specific control_plane-owned resources are still attached to 'baseline' policies #273
