### PR TITLE
refactor: remove '_<env>' suffix from each env's outputs

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -25,9 +25,6 @@ jobs:
           - environment: staging
             github_environment: staging-plan
             working_directory: ./environments/staging
-          - environment: control-plane-account
-            github_environment: control-plane-plan
-            working_directory: ./bootstrap/control_plane/account
           - environment: control-plane-identity-center
             github_environment: control-plane-plan
             working_directory: ./bootstrap/control_plane/identity_center

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -1,19 +1,19 @@
-output "lambda_cmk_arn_dev" {
+output "lambda_cmk_arn" {
   description = "ARN of the 'dev' env's CMK used to encrypt Lambda functions"
   value       = module.baseline.lambda_cmk_arn
 }
 
-output "secrets_manager_cmk_arn_dev" {
+output "secrets_manager_cmk_arn" {
   description = "ARN of the 'dev' env's CMK used to encrypt Secrets Manager secrets"
   value       = module.baseline.secrets_manager_cmk_arn
 }
 
-output "logs_cmk_decrypt_policy_name_dev" {
+output "logs_cmk_decrypt_policy_name" {
   description = "'Name' attribute of the 'dev' env's 'Logs CMK Decrypt Policy' resource"
   value       = module.baseline.logs_cmk_decrypt_policy_name
 }
 
-output "logs_s3_readonly_policy_name_dev" {
+output "logs_s3_readonly_policy_name" {
   description = "'Name' attribute of the 'dev' env's 'Logs S3 Readonly Policy' resource"
   value       = module.baseline.logs_s3_readonly_policy_name
 }

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -1,19 +1,19 @@
-output "lambda_cmk_arn_prod" {
+output "lambda_cmk_arn" {
   description = "ARN of the 'prod' env's CMK used to encrypt Lambda functions"
   value       = module.baseline.lambda_cmk_arn
 }
 
-output "secrets_manager_cmk_arn_prod" {
+output "secrets_manager_cmk_arn" {
   description = "ARN of the 'prod' env's CMK used to encrypt Secrets Manager secrets"
   value       = module.baseline.secrets_manager_cmk_arn
 }
 
-output "logs_cmk_decrypt_policy_name_prod" {
+output "logs_cmk_decrypt_policy_name" {
   description = "'Name' attribute of the 'prod' env's 'Logs CMK Decrypt Policy' resource"
   value       = module.baseline.logs_cmk_decrypt_policy_name
 }
 
-output "logs_s3_readonly_policy_name_prod" {
+output "logs_s3_readonly_policy_name" {
   description = "'Name' attribute of the 'prod' env's 'Logs S3 Readonly Policy' resource"
   value       = module.baseline.logs_s3_readonly_policy_name
 }

--- a/environments/staging/outputs.tf
+++ b/environments/staging/outputs.tf
@@ -1,19 +1,19 @@
-output "lambda_cmk_arn_staging" {
+output "lambda_cmk_arn" {
   description = "ARN of the 'staging' env's CMK used to encrypt Lambda functions"
   value       = module.baseline.lambda_cmk_arn
 }
 
-output "secrets_manager_cmk_arn_staging" {
+output "secrets_manager_cmk_arn" {
   description = "ARN of the 'staging' env's CMK used to encrypt Secrets Manager secrets"
   value       = module.baseline.secrets_manager_cmk_arn
 }
 
-output "logs_cmk_decrypt_policy_name_staging" {
+output "logs_cmk_decrypt_policy_name" {
   description = "'Name' attribute of the 'staging' env's 'Logs CMK Decrypt Policy' resource"
   value       = module.baseline.logs_cmk_decrypt_policy_name
 }
 
-output "logs_s3_readonly_policy_name_staging" {
+output "logs_s3_readonly_policy_name" {
   description = "'Name' attribute of the 'staging' env's 'Logs S3 Readonly Policy' resource"
   value       = module.baseline.logs_s3_readonly_policy_name
 }


### PR DESCRIPTION
Reduce confusion with setting vars