### PR TITLE
docs: refine 'identity_center' stack README.md and create 'tamper_detection' module README.md

### DIFF
--- a/bootstrap/control_plane/identity_center/README.md
+++ b/bootstrap/control_plane/identity_center/README.md
@@ -78,6 +78,16 @@ Identity Center roles that depend on environment-specific policies (e.g., logs a
 
 ---
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `dev_permission_set_arns` | ARNs of the `dev` environment's permission sets |
+| `prod_permission_set_arns` | ARNs of the `prod` environment's permission sets |
+| `staging_permission_set_arns` | ARNs of the `staging` environment's permission sets |
+
+---
+
 ## ⚠️ Important Notes
 
 - Customer-managed policy attachments require:

--- a/bootstrap/control_plane/identity_center/README.md
+++ b/bootstrap/control_plane/identity_center/README.md
@@ -58,7 +58,7 @@ Identity Center roles that depend on environment-specific policies (e.g., logs a
 
 3. **Re-apply Identity Center**
    - Pass policy names as variables, which are output by the `baseline` stack deployed by `environment/<env>`
-   - Attach customer-managed policies to permission sets
+   - Attach customer-managed policies to permission sets by defining policy name variables and re-apply the `identity_center` substack
 
 ---
 

--- a/bootstrap/control_plane/identity_center/README.md
+++ b/bootstrap/control_plane/identity_center/README.md
@@ -62,6 +62,22 @@ Identity Center roles that depend on environment-specific policies (e.g., logs a
 
 ---
 
+## Inputs
+
+| Name | Description |
+|------|-------------|
+| `cloud_name` | Name of cloud environment |
+| `primary_region_<env>` | AWS region used by specified environment |
+| `enable_secops_analyst_<env>` | Enable SecOps-Analyst resources in specified environment |
+| `enable_secops_engineer_<env>` | Enable SecOps-Engineer resources in specified environment |
+| `account_id_<env>` | AWS account ID of specified environment |
+| `secops_analyst_group_name` | Name of the SecOps-Analyst Identity Center group |
+| `secops_engineer_group_name` | Name of the SecOps-Engineer Identity Center group |
+| `logs_s3_readonly_policy_name_<env>` | Name of the Centralized Logs S3 bucket's ReadOnly IAM policy in specified environment |
+| `logs_cmk_decrypt_policy_name_<env>` | Name of the Centralized Logs S3 bucket CMK's Decrypt IAM policy |
+
+---
+
 ## ⚠️ Important Notes
 
 - Customer-managed policy attachments require:

--- a/bootstrap/control_plane/state/README.md
+++ b/bootstrap/control_plane/state/README.md
@@ -64,7 +64,7 @@ Unlike other stacks:
 - It bootstraps the remote backend used by all other stacks
 
 After deployment:
-- Bootstrap and baseline use the S3 backend created here
+- `bootstrap` and `baseline` use the S3 backend created here
 - This stack may optionally be migrated to remote state later
 
 ---

--- a/modules/security/tamper_detection/README.md
+++ b/modules/security/tamper_detection/README.md
@@ -1,0 +1,143 @@
+# Tamper Detection Module
+
+## Overview
+
+The `tamper_detection` module creates an EventBridge-based alerting control for detecting attempts to disable, delete, or modify core AWS security services.
+
+When a matching API call is observed through CloudTrail, the module sends a formatted alert to an SNS topic.
+
+---
+
+## Purpose
+
+This module helps detect suspicious changes to security controls such as:
+
+- CloudTrail
+- GuardDuty
+- Security Hub
+- KMS
+
+These events may indicate an attempt to weaken logging, detection, encryption, or security monitoring.
+
+---
+
+## Architecture
+
+```
+AWS API Call
+    |
+    v
+CloudTrail Event
+    |
+    v
+EventBridge Rule
+    |
+    v
+SNS Topic
+    |
+    v
+SecOps Notification
+```
+
+---
+
+## Detected Actions
+
+The module monitors for tampering actions including:
+
+### CloudTrail
+
+- `StopLogging`
+- `DeleteTrail`
+- `UpdateTrail`
+- `PutEventSelectors`
+- `PutInsightSelectors`
+
+### GuardDuty
+
+- `DeleteDetector`
+- `UpdateDetector`
+- `DisassociateFromMasterAccount`
+- `DisassociateMembers`
+
+### Security Hub
+
+- `DisableSecurityHub`
+- `DeleteMembers`
+- `DisassociateFromMasterAccount`
+
+### KMS
+
+- `ScheduleKeyDeletion`
+- `DisableKey`
+- `PutKeyPolicy`
+- `UpdateKeyDescription`
+
+---
+
+## Alert Behavior
+
+When a matching event is detected, EventBridge sends a formatted message to the configured SNS topic.
+
+The alert includes:
+
+- Action
+- Service
+- Time
+- AWS account
+- Region
+- Actor ARN
+- Source IP
+- MFA status
+
+---
+
+## Usage
+
+```hcl
+module "tamper_detection" {
+  source = "./tamper_detection"
+
+  cloud_name      = var.cloud_name
+  environment     = var.environment
+  name_prefix     = local.name_prefix
+  alert_topic_arn = var.alert_topic_arn
+}
+```
+
+---
+
+## Inputs
+
+| Name | Description |
+|------|-------------|
+| `cloud_name` | Name of the cloud environment |
+| `environment` | Environment name, such as `dev`, `staging`, or `prod` |
+| `name_prefix` | Naming prefix used for created resources |
+| `alert_topic_arn` | SNS topic ARN used for tamper alerts |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `tamper_detection_rule_name` | Name of the EventBridge tamper detection rule |
+| `tamper_detection_rule_arn` | ARN of the EventBridge tamper detection rule |
+
+---
+
+## Important Notes
+
+- This module depends on CloudTrail events being available in EventBridge.
+- This module does not prevent tampering; it detects and alerts on suspicious activity.
+- Alerts should be reviewed by SecOps or platform administrators.
+- The SNS topic should be monitored by the appropriate security response team.
+
+---
+
+## Summary
+
+The `tamper_detection` module provides a lightweight but important detection layer for security control changes.
+
+It helps identify attempts to disable or weaken AWS security services and routes those events to SNS for investigation.


### PR DESCRIPTION
This PR addresses the following issues:

Add 'Inputs' and 'Outputs' sections to identity_center stack's README.md file #286
Create README.md file for the 'tamper_detection' childmodule (parent module = security) #287