### PR TITLE
chore: revise docs/lambda_tests/ip_enrichment.md file and fix ip enrichment lambda

### DIFF
--- a/docs/lambda_tests/ec2_rollback.md
+++ b/docs/lambda_tests/ec2_rollback.md
@@ -546,7 +546,7 @@ aws events put-events \
 
 ---
 
-## Test 7 - Wrong Detail Type
+## Test 6 - Wrong Detail Type
 
 ### Purpose
 

--- a/docs/lambda_tests/ec2_rollback.md
+++ b/docs/lambda_tests/ec2_rollback.md
@@ -273,8 +273,8 @@ These verification commands require read access to EC2 and CloudWatch Logs. The 
 Run these verification commands from a terminal in a separate window authenticated as one of the following:
 
 - IAM administrator user
-- SecOps-Analyst role
-- SecOps-Engineer role
+- SecOps-Analyst role (with `lambda:Invoke` permission attached)
+- SecOps-Engineer role (with `lambda:Invoke` permission attached)
 - Authorized CI/CD or break-glass role
 
 Before continuing, confirm your AWS CLI is authenticated to the correct target account.

--- a/docs/lambda_tests/ec2_rollback.md
+++ b/docs/lambda_tests/ec2_rollback.md
@@ -273,9 +273,9 @@ These verification commands require read access to EC2 and CloudWatch Logs. The 
 Run these verification commands from a terminal in a separate window authenticated as one of the following:
 
 - IAM administrator user
-- SecOps-Analyst role (with `lambda:Invoke` permission attached)
-- SecOps-Engineer role (with `lambda:Invoke` permission attached)
-- Authorized CI/CD or break-glass role
+- Authorized CI/CD role
+- Break-glass role
+- A specifically authorized engineering/debug role with `lambda:InvokeFunction`
 
 Before continuing, confirm your AWS CLI is authenticated to the correct target account.
 
@@ -435,7 +435,7 @@ aws events put-events \
 
 Confirm that the EC2 instance was restored to its pre-isolation security group configuration.
 
-Run these from a terminal authenticated as either an IAM administrator user, the SecOps-Analyst role, SecOps-Engineer role, or an authorized CI/CD / break-glass role.
+Run these from a terminal authenticated as one of the identities defined in the `Verification Commands` section of this guide.
 
 ### Check Security Groups
 

--- a/docs/lambda_tests/ec2_rollback.md
+++ b/docs/lambda_tests/ec2_rollback.md
@@ -270,7 +270,7 @@ Use the following commands to confirm the target instance state before and after
 
 These verification commands require read access to EC2 and CloudWatch Logs. The `SecOps-Operator` role is intentionally limited to EventBridge actions and should not be expected to run these commands.
 
-Run these verification commands from a separate terminal authenticated as one of the following:
+Run these verification commands from a terminal in a separate window authenticated as one of the following:
 
 - IAM administrator user
 - SecOps-Analyst role

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -8,7 +8,7 @@ The IP Enrichment Lambda processes Security Hub findings, extracts public IP add
 
 Depending on configuration, the Lambda can also write enrichment notes back to Security Hub findings.
 
-This test validates the IP enrichment workflow in the context of the full `tf-secure-baseline` architecture, including:
+This test validates the `IP Enrichment` workflow in the context of the full `tf-secure-baseline` architecture, including:
 
 - Multi-account environments: `dev`, `staging`, and `prod`
 - Security Hub finding ingestion

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -60,22 +60,22 @@ Before running these tests, confirm:
 
 The IP Enrichment Lambda should have the following environment variables configured:
 
-%%%text
+```text
 SNS_TOPIC_ARN
 THREAT_INTEL_SECRET_ARN
 WRITE_TO_SECURITYHUB
 MAX_IPS_PER_EVENT
 ABUSEIPDB_MAX_AGE_DAYS
 MAX_IPS_EXTRACTED
-%%%
+```
 
 ### Writeback Behavior
 
 If:
 
-%%%text
+```text
 WRITE_TO_SECURITYHUB=true
-%%%
+```
 
 then full writeback validation requires:
 
@@ -109,7 +109,7 @@ Set these values before running the tests.
 
 Update the values for the environment you are testing.
 
-%%%bash
+```bash
 export AWS_PAGER=""
 export AWS_REGION="us-east-1"
 export CLOUD_NAME="tf-secure-baseline"
@@ -120,33 +120,33 @@ export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
 # Optional: only required for Security Hub writeback validation
 export REAL_SECURITY_HUB_FINDING_ID="<REAL-SECURITY-HUB-FINDING-ID>"
 export REAL_PRODUCT_ARN="<REAL-PRODUCT-ARN>"
-%%%
+```
 
 For staging:
 
-%%%bash
+```bash
 export ENVIRONMENT="staging"
 export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
-%%%
+```
 
 For prod:
 
-%%%bash
+```bash
 export ENVIRONMENT="prod"
 export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
-%%%
+```
 
 The Lambda function name is dynamically generated from:
 
-%%%text
+```text
 ${cloud_name}-${environment}-ip-enrichment
-%%%
+```
 
 Example:
 
-%%%text
+```text
 tf-secure-baseline-dev-ip-enrichment
-%%%
+```
 
 ---
 
@@ -154,9 +154,9 @@ tf-secure-baseline-dev-ip-enrichment
 
 Before running the tests, confirm your AWS CLI is authenticated to the target environment.
 
-%%%bash
+```bash
 aws sts get-caller-identity
-%%%
+```
 
 Confirm the returned account ID matches the environment being tested.
 
@@ -170,17 +170,17 @@ These commands require read access to Lambda, CloudWatch Logs, SNS, and optional
 
 ### Check Lambda Logs
 
-%%%bash
+```bash
 aws logs tail "/aws/lambda/${FUNCTION_NAME}" \
   --region "${AWS_REGION}" \
   --since 15m
-%%%
+```
 
 ### Confirm Security Hub Finding Note
 
 Use this only when testing with a real finding ID and real ProductArn.
 
-%%%bash
+```bash
 aws securityhub get-findings \
   --region "${AWS_REGION}" \
   --filters "{
@@ -192,15 +192,15 @@ aws securityhub get-findings \
     ]
   }" \
   --query 'Findings[].Note'
-%%%
+```
 
 If the `Note` block is returned with `Text`, `UpdatedBy`, and `UpdatedAt`, the Lambda successfully wrote enrichment context back to the Security Hub finding.
 
 You can also confirm this in the AWS Console:
 
-%%%text
+```text
 Security Hub -> Findings -> Open finding -> History -> Note Added
-%%%
+```
 
 ---
 
@@ -223,7 +223,7 @@ Validate that the Lambda extracts public IPv4 addresses from a Security Hub find
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -271,29 +271,29 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response body pattern:
 
-%%%json
+```json
 {
   "statusCode": 200,
   "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"
 }
-%%%
+```
 
 ### Optional Security Hub Writeback Check
 
-%%%bash
+```bash
 aws securityhub get-findings \
   --region "${AWS_REGION}" \
   --filters "{
@@ -305,7 +305,7 @@ aws securityhub get-findings \
     ]
   }" \
   --query 'Findings[].Note'
-%%%
+```
 
 ---
 
@@ -326,7 +326,7 @@ Validate that the Lambda extracts public IPv6 addresses from a Security Hub find
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -374,25 +374,25 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response body pattern:
 
-%%%json
+```json
 {
   "statusCode": 200,
   "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"
 }
-%%%
+```
 
 ---
 
@@ -412,7 +412,7 @@ Validate that private, non-public IP addresses are ignored and not enriched.
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -460,29 +460,29 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response body pattern:
 
-%%%json
+```json
 {
   "statusCode": 200,
   "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"
 }
-%%%
+```
 
 ### Confirm Absence of Security Hub Writeback
 
-%%%bash
+```bash
 aws securityhub get-findings \
   --region "${AWS_REGION}" \
   --filters "{
@@ -494,13 +494,13 @@ aws securityhub get-findings \
     ]
   }" \
   --query 'Findings[].Note'
-%%%
+```
 
 Expected output if no previous note exists:
 
-%%%json
+```json
 []
-%%%
+```
 
 ---
 
@@ -520,7 +520,7 @@ Validate that a finding with no IP data is handled safely.
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -562,25 +562,25 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response body pattern:
 
-%%%json
+```json
 {
   "statusCode": 200,
   "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"
 }
-%%%
+```
 
 ---
 
@@ -600,7 +600,7 @@ Validate that enrichment still executes when public IPs are present, but Securit
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -645,16 +645,16 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response depends on implementation.
 
@@ -682,7 +682,7 @@ Validate that the Lambda handles an event with no findings safely.
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -703,25 +703,25 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 Expected Lambda response body pattern:
 
-%%%json
+```json
 {
   "statusCode": 400,
   "body": "{\"message\": \"No findings in event\"}"
 }
-%%%
+```
 
 ---
 
@@ -742,7 +742,7 @@ Validate that the Lambda can extract multiple public IP addresses embedded in fi
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -789,16 +789,16 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 ---
 
@@ -817,7 +817,7 @@ Validate that duplicate public IP addresses do not cause duplicate enrichment re
 
 ### Manual Event via AWS CLI
 
-%%%bash
+```bash
 aws lambda invoke \
   --region "${AWS_REGION}" \
   --function-name "${FUNCTION_NAME}" \
@@ -865,16 +865,16 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-%%%
+```
 
 ### Expected CLI Output
 
-%%%json
+```json
 {
   "StatusCode": 200,
   "ExecutedVersion": "$LATEST"
 }
-%%%
+```
 
 ---
 
@@ -886,7 +886,7 @@ Use this section to validate the event-driven workflow.
 
 ## Integration Path
 
-%%%text
+```text
 Security Hub Finding
     |
     v
@@ -904,7 +904,7 @@ AbuseIPDB Lookup
     +--> SNS Notification
     |
     +--> Optional Security Hub Note Writeback
-%%%
+```
 
 ## Expected Integration Behavior
 

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -886,6 +886,14 @@ response.json && cat response.json && rm response.json
 }
 ```
 
+Expected Lambda response body pattern:
+
+```json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"Processing complete\", \"resultCount\": 1}"
+}
+```
 ---
 
 # EventBridge / Security Hub Integration Validation

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -93,9 +93,9 @@ Direct Lambda invocation requires a principal with permission to invoke the func
 Use one of the following:
 
 - IAM administrator user
-- SecOps-Engineer role
 - Authorized CI/CD role
-- Another role with `lambda:InvokeFunction`
+- Break-glass role
+- A specifically authorized engineering/debug role with `lambda:InvokeFunction`
 
 Security Hub writeback verification requires read access to Security Hub findings.
 

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -196,6 +196,8 @@ aws securityhub get-findings \
 
 If the `Note` block is returned with `Text`, `UpdatedBy`, and `UpdatedAt`, the Lambda successfully wrote enrichment context back to the Security Hub finding.
 
+Before you run the `IP Enrichment` Lambda function, an empty list returned is expected.
+
 You can also confirm this in the AWS Console:
 
 ```text

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -810,6 +810,14 @@ response.json && cat response.json && rm response.json
 }
 ```
 
+Expected Lambda response body pattern:
+
+```json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"Processing complete\", \"resultCount\": 3}"
+}
+
 ---
 
 ## Test 8 - Duplicate IP Addresses

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -732,7 +732,13 @@ Expected Lambda response body pattern:
 
 ### Purpose
 
-Validate that the Lambda can extract multiple public IP addresses embedded in finding fields outside the `Network` object.
+### Purpose
+
+Validate that the Lambda can extract and enrich public IP addresses embedded in provider-specific finding fields, such as `ProductFields`.
+
+Security Hub findings are not always consistent about where network indicators appear. Some findings place IP addresses in normalized fields like `Network.SourceIpV4`, while others include them only in text-heavy or provider-specific fields.
+
+This test confirms the Lambda can still enrich public IP indicators even when they appear outside the dedicated Security Hub network fields.
 
 ### Expected Outcome
 

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -503,6 +503,7 @@ Expected output if no previous note exists:
 ```json
 []
 ```
+> If you ran Test 1 with `WRITE_TO_SECURITYHUB` enabled, this test should return no additional IPs.
 
 ---
 

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -962,6 +962,10 @@ After running tests, confirm:
 
 # Troubleshooting
 
+Errors associated with these tests are often the result of an invalid environment variable.
+
+Ensure that all environment variables are correctly set prior to following the troubleshooting steps outlined below. 
+
 ## Lambda invocation fails
 
 Check:

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -659,7 +659,14 @@ response.json && cat response.json && rm response.json
 }
 ```
 
-Expected Lambda response depends on implementation.
+Expected Lambda response body pattern:
+
+```json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"No valid identifers for Security Hub writeback\"}"
+}
+```
 
 Acceptable outcomes:
 

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -742,8 +742,6 @@ This test confirms the Lambda can still enrich public IP indicators even when th
 
 ### Expected Outcome
 
-### Expected Outcome
-
 - Lambda executes successfully.
 - Public IP addresses are extracted from `ProductFields`.
 - IP reputation data is retrieved.

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -1,67 +1,248 @@
-# LAMBDA FUNCTION TESTS
+# LAMBDA FUNCTION TESTS - IP ENRICHMENT
 
-Purpose:
-Manual test events used to validate Lambda automation behavior before and after changes.
+## Purpose
 
-### How to Use
-* Replace ```<YOUR-ACCOUNT-ID>``` with your AWS account ID
-* Replace ```<REAL-SECURITY-HUB-FINDING-ID>``` with a valid Security Hub finding ID if you want to test Security Hub writeback
-* Replace ```<REAL-PRODUCT-ARN>``` with the ProductArn associated with that finding
-* Ensure the ```THREAT_INTEL_SECRET_ARN``` secret exists and contains a valid AbuseIPDB API key
-* Confirm expected outcome based on the **Expected Outcome** section of each test
+This document provides manual tests used to validate the **IP Enrichment Lambda** behavior before and after changes.
+
+The IP Enrichment Lambda processes Security Hub findings, extracts public IP addresses, enriches them using threat intelligence data, and sends the results to the configured SecOps SNS topic.
+
+Depending on configuration, the Lambda can also write enrichment notes back to Security Hub findings.
+
+This test validates the IP enrichment workflow in the context of the full `tf-secure-baseline` architecture, including:
+
+- Multi-account environments: `dev`, `staging`, and `prod`
+- Security Hub finding ingestion
+- EventBridge-driven Lambda execution
+- Secrets Manager-based AbuseIPDB API key retrieval
+- SNS-based SecOps notification
+- Optional Security Hub finding note writeback
+
+---
+
+## Testing Approach
+
+This document includes **direct Lambda invocation tests** used for development and debugging.
+
+These tests:
+
+- Bypass EventBridge
+- Bypass real Security Hub event generation
+- Invoke the IP Enrichment Lambda directly
+- Validate IP extraction, enrichment, SNS notification, and optional Security Hub writeback behavior
+
+In production, this Lambda is triggered by:
+
+- Security Hub findings
+- EventBridge rules
+
+Direct invocation is useful for validating Lambda behavior without waiting for a real Security Hub finding.
+
+---
+
+## Prerequisites
+
+Before running these tests, confirm:
+
+- The target environment has been deployed.
+- Security Hub is enabled in the target account.
+- The IP Enrichment Lambda exists.
+- The SecOps SNS topic exists.
+- The threat intelligence secret exists in Secrets Manager.
+- The secret contains a valid AbuseIPDB API key.
+- The Lambda execution role can read the secret.
+- The Lambda execution role can publish to SNS.
+- The Lambda execution role can use the required KMS keys.
+- If Security Hub writeback is enabled, the Lambda execution role can call `securityhub:BatchUpdateFindings`.
+
+---
+
+## Lambda Environment Variables
+
+The IP Enrichment Lambda should have the following environment variables configured:
+
+%%%text
+SNS_TOPIC_ARN
+THREAT_INTEL_SECRET_ARN
+WRITE_TO_SECURITYHUB
+MAX_IPS_PER_EVENT
+ABUSEIPDB_MAX_AGE_DAYS
+MAX_IPS_EXTRACTED
+%%%
+
+### Writeback Behavior
+
+If:
+
+%%%text
+WRITE_TO_SECURITYHUB=true
+%%%
+
+then full writeback validation requires:
+
+- A real Security Hub finding ID
+- The real ProductArn associated with that finding
+
+If test events use fake finding IDs or fake ProductArns, enrichment and SNS notification may still work, but Security Hub writeback may fail or be skipped depending on the Lambda implementation.
+
+---
+
+## Access Requirements
+
+Direct Lambda invocation requires a principal with permission to invoke the function.
+
+Use one of the following:
+
+- IAM administrator user
+- SecOps-Engineer role
+- Authorized CI/CD role
+- Another role with `lambda:InvokeFunction`
+
+Security Hub writeback verification requires read access to Security Hub findings.
+
+CloudWatch log verification requires read access to CloudWatch Logs.
+
+---
+
+## Environment Variables
+
+Set these values before running the tests.
+
+Update the values for the environment you are testing.
+
+%%%bash
+export AWS_PAGER=""
+export AWS_REGION="us-east-1"
+export CLOUD_NAME="tf-secure-baseline"
+export ENVIRONMENT="dev"
+export ACCOUNT_ID="<TARGET-ACCOUNT-ID>"
+export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
+
+# Optional: only required for Security Hub writeback validation
+export REAL_SECURITY_HUB_FINDING_ID="<REAL-SECURITY-HUB-FINDING-ID>"
+export REAL_PRODUCT_ARN="<REAL-PRODUCT-ARN>"
+%%%
+
+For staging:
+
+%%%bash
+export ENVIRONMENT="staging"
+export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
+%%%
+
+For prod:
+
+%%%bash
+export ENVIRONMENT="prod"
+export FUNCTION_NAME="${CLOUD_NAME}-${ENVIRONMENT}-ip-enrichment"
+%%%
+
+The Lambda function name is dynamically generated from:
+
+%%%text
+${cloud_name}-${environment}-ip-enrichment
+%%%
+
+Example:
+
+%%%text
+tf-secure-baseline-dev-ip-enrichment
+%%%
+
+---
+
+## Verify AWS CLI Identity
+
+Before running the tests, confirm your AWS CLI is authenticated to the target environment.
+
+%%%bash
+aws sts get-caller-identity
+%%%
+
+Confirm the returned account ID matches the environment being tested.
+
+---
+
+## Verification Commands
+
+Use the following commands to verify Lambda behavior after running tests.
+
+These commands require read access to Lambda, CloudWatch Logs, SNS, and optionally Security Hub.
+
+### Check Lambda Logs
+
+%%%bash
+aws logs tail "/aws/lambda/${FUNCTION_NAME}" \
+  --region "${AWS_REGION}" \
+  --since 15m
+%%%
+
+### Confirm Security Hub Finding Note
+
+Use this only when testing with a real finding ID and real ProductArn.
+
+%%%bash
+aws securityhub get-findings \
+  --region "${AWS_REGION}" \
+  --filters "{
+    \"Id\": [
+      {
+        \"Value\": \"${REAL_SECURITY_HUB_FINDING_ID}\",
+        \"Comparison\": \"EQUALS\"
+      }
+    ]
+  }" \
+  --query 'Findings[].Note'
+%%%
+
+If the `Note` block is returned with `Text`, `UpdatedBy`, and `UpdatedAt`, the Lambda successfully wrote enrichment context back to the Security Hub finding.
+
+You can also confirm this in the AWS Console:
+
+%%%text
+Security Hub -> Findings -> Open finding -> History -> Note Added
+%%%
 
 ---
 
 # IP ENRICHMENT LAMBDA TESTS
 
-## PREREQUISITES
-* Lambda environment variables are configured:
-    * ```SNS_TOPIC_ARN```
-    * ```THREAT_INTEL_SECRET_ARN```
-    * ```WRITE_TO_SECURITYHUB```
-    * ```MAX_IPS_PER_EVENT```
-    * ```ABUSEIPDB_MAX_AGE_DAYS```
-    * ```MAX_IPS_EXTRACTED```
-* Lambda IAM role has permission to:
-    * Read the threat intel secret from Secrets Manager
-    * Publish to the configured SNS topic
-    * Call 'securityhub:BatchUpdateFindings'
-* If 'WRITE_TO_SECURITYHUB=true', use a real Security Hub finding ID and ProductArn for full writeback validation
+## Test 1 - CRITICAL Finding with Public IPv4 Addresses
 
----
+### Purpose
 
-### TEST 1 -- CRITICAL FINDING WITH PUBLIC IPV4 ADDRESSES
+Validate that the Lambda extracts public IPv4 addresses from a Security Hub finding, enriches them, sends an SNS notification, and optionally writes a note back to Security Hub.
 
-#### Expected Outcome
-* Lambda executes
-* Public IPs extracted from finding
-* IP reputation data retrieved from AbuseIPDB
-* SNS notification sent to configured SNS topic
-* If valid finding identifiers supplied and 'WRITE_TO_SECURITYHUB=true', note written back to Security Hub finding
-* No errors in logs
+### Expected Outcome
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+- Lambda executes successfully.
+- Public IPv4 addresses are extracted.
+- IP reputation data is retrieved from AbuseIPDB.
+- SNS notification is sent to the configured SecOps topic.
+- If valid Security Hub identifiers are supplied and `WRITE_TO_SECURITYHUB=true`, a note is written back to the finding.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-1",
+  "id": "test-ip-enrichment-critical-ipv4",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "<YOUR-ACCOUNT-ID>",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": [
       {
-        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-        "AwsAccountId": "<YOUR-ACCOUNT-ID>",
-        "Region": "us-east-1",
+        "Title": "Manual test CRITICAL finding with public IPv4 addresses",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
         "ProductName": "Security Hub",
         "Resources": [
           {
@@ -69,10 +250,14 @@ aws lambda invoke \
             "Type": "AwsS3Bucket"
           }
         ],
-        "Id": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "ProductArn": "<REAL-PRODUCT-ARN>",
-        "Severity": { "Label": "CRITICAL" },
-        "Workflow": { "Status": "NEW" },
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "CRITICAL"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
         "Network": {
           "SourceIpV4": "103.37.6.88"
         },
@@ -86,68 +271,81 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
-{
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
-}
-{"statusCode": 200, "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"}
-```
+%%%
 
-##### Confirm Write to Security Hub Finding
-Run the following from the CLI:
-```bash
+### Expected CLI Output
+
+%%%json
+{
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
+}
+%%%
+
+Expected Lambda response body pattern:
+
+%%%json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"
+}
+%%%
+
+### Optional Security Hub Writeback Check
+
+%%%bash
 aws securityhub get-findings \
-  --filters '{
-    "Id": [
+  --region "${AWS_REGION}" \
+  --filters "{
+    \"Id\": [
       {
-        "Value": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "Comparison": "EQUALS"
+        \"Value\": \"${REAL_SECURITY_HUB_FINDING_ID}\",
+        \"Comparison\": \"EQUALS\"
       }
     ]
-  }' \
+  }" \
   --query 'Findings[].Note'
-```
-If the "Note" JSON block is returned ("Text", "UpdatedBy", and "UpdatedAt" fields), the IP Enrichment Lambda successfully wrote to the Security Hub finding ✅
-> NOTE: You can also confirm this via the AWS console by navigating to the Security Hub module, opening the referenced Security Hub finding, and checking the 'History' tab for 'Note Added'
+%%%
 
-Repeat this test for ALL other finding serverities, replacing "CRITICAL" in *"Severity": { "Label": "CRITICAL" }* with "HIGH", "MEDIUM", and "LOW"
+---
 
+## Test 2 - HIGH Finding with Public IPv6 Addresses
 
-### TEST 2 -- HIGH FINDING WITH IPv6 ADDRESS
+### Purpose
 
-#### Expected Outcome
-* Lambda executes
-* Public IPs extracted from finding
-* IP reputation data retrieved from AbuseIPDB
-* SNS notification sent to configured SNS topic
-* If valid finding identifiers supplied and 'WRITE_TO_SECURITYHUB=true', note written back to Security Hub finding
-* No errors in logs
+Validate that the Lambda extracts public IPv6 addresses from a Security Hub finding and enriches them.
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+### Expected Outcome
+
+- Lambda executes successfully.
+- Public IPv6 addresses are extracted.
+- IP reputation data is retrieved from AbuseIPDB.
+- SNS notification is sent to the configured SecOps topic.
+- If valid Security Hub identifiers are supplied and `WRITE_TO_SECURITYHUB=true`, a note is written back to the finding.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-1",
+  "id": "test-ip-enrichment-high-ipv6",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "<YOUR-ACCOUNT-ID>",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": [
       {
-        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-        "AwsAccountId": "<YOUR-ACCOUNT-ID>",
-        "Region": "us-east-1",
+        "Title": "Manual test HIGH finding with public IPv6 addresses",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
         "ProductName": "Security Hub",
         "Resources": [
           {
@@ -155,12 +353,16 @@ aws lambda invoke \
             "Type": "AwsS3Bucket"
           }
         ],
-        "Id": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "ProductArn": "<REAL-PRODUCT-ARN>",
-        "Severity": { "Label": "CRITICAL" },
-        "Workflow": { "Status": "NEW" },
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "HIGH"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
         "Network": {
-          "SourceIpV4": "2600:1f1a:4d5e:c202:c650:7b48:85af:a5c5"
+          "SourceIpV6": "2600:1f1a:4d5e:c202:c650:7b48:85af:a5c5"
         },
         "ProductFields": {
           "someField": "connection from 2600:4040:251a:7200:d278:1c82:12a7:b782 observed"
@@ -172,65 +374,64 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
+%%%
+
+### Expected CLI Output
+
+%%%json
 {
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
 }
-{"statusCode": 200, "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"}
-```
+%%%
 
-##### Confirm Write to Security Hub Finding
-Run the following from the CLI:
-```bash
-aws securityhub get-findings \
-  --filters '{
-    "Id": [
-      {
-        "Value": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "Comparison": "EQUALS"
-      }
-    ]
-  }' \
-  --query 'Findings[].Note'
-```
-If the "Note" JSON block is returned ("Text", "UpdatedBy", and "UpdatedAt" fields), the IP Enrichment Lambda successfully wrote to the Security Hub finding ✅
-> NOTE: You can also confirm this via the AWS console by navigating to the Security Hub module, opening the referenced Security Hub finding, and checking the 'History' tab for 'Note Added'
+Expected Lambda response body pattern:
 
+%%%json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"Processing complete\", \"resultCount\": 2}"
+}
+%%%
 
-### TEST 3 -- FINDING WITH PRIVATE/NON-PUBLIC IP ONLY
+---
 
-#### Expected Outcome
-* Lambda executes
-* No IP addresses are enriched
-* No SNS message is sent
-* No Security Hub writeback performed
-* No errors in logs
+## Test 3 - Finding with Private IP Addresses Only
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+### Purpose
+
+Validate that private, non-public IP addresses are ignored and not enriched.
+
+### Expected Outcome
+
+- Lambda executes successfully.
+- No public IP addresses are enriched.
+- No SNS message is sent.
+- No Security Hub writeback is performed.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-1",
+  "id": "test-ip-enrichment-private-only",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "<YOUR-ACCOUNT-ID>",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": [
       {
-        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-        "AwsAccountId": "<YOUR-ACCOUNT-ID>",
-        "Region": "us-east-1",
+        "Title": "Manual test finding with private IP addresses only",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
         "ProductName": "Security Hub",
         "Resources": [
           {
@@ -238,10 +439,14 @@ aws lambda invoke \
             "Type": "AwsS3Bucket"
           }
         ],
-        "Id": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "ProductArn": "<REAL-PRODUCT-ARN>",
-        "Severity": { "Label": "CRITICAL" },
-        "Workflow": { "Status": "NEW" },
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "CRITICAL"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
         "Network": {
           "SourceIpV4": "10.0.1.15"
         },
@@ -255,67 +460,86 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
+%%%
+
+### Expected CLI Output
+
+%%%json
 {
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
 }
-{"statusCode": 200, "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"}
-```
+%%%
 
-##### Confirm Absense of Write to Security Hub Finding
+Expected Lambda response body pattern:
 
-Run the following from the CLI:
-```bash
+%%%json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"
+}
+%%%
+
+### Confirm Absence of Security Hub Writeback
+
+%%%bash
 aws securityhub get-findings \
-  --filters '{
-    "Id": [
+  --region "${AWS_REGION}" \
+  --filters "{
+    \"Id\": [
       {
-        "Value": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "Comparison": "EQUALS"
+        \"Value\": \"${REAL_SECURITY_HUB_FINDING_ID}\",
+        \"Comparison\": \"EQUALS\"
       }
     ]
-  }' \
+  }" \
   --query 'Findings[].Note'
-```
-Expected Outcome:
-```json
+%%%
+
+Expected output if no previous note exists:
+
+%%%json
 []
-```
-> NOTE: You can also confirm this via the AWS console by navigating to the Security Hub module, opening the referenced Security Hub finding, and checking the 'History' tab for 'Note Added'
+%%%
 
-### TEST 4 -- HIGH FINDING WITH NO IP DATA
-#### Expected Outcome
-* Lambda executes
-* No IP addresses are enriched
-* No SNS message is sent
-* No Security Hub writeback performed
-* No errors in logs
+---
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+## Test 4 - HIGH Finding with No IP Data
+
+### Purpose
+
+Validate that a finding with no IP data is handled safely.
+
+### Expected Outcome
+
+- Lambda executes successfully.
+- No IP addresses are enriched.
+- No SNS message is sent.
+- No Security Hub writeback is performed.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-1",
+  "id": "test-ip-enrichment-no-ip-data",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "<YOUR-ACCOUNT-ID>",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": [
       {
-        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-        "AwsAccountId": "<YOUR-ACCOUNT-ID>",
-        "Region": "us-east-1",
+        "Title": "Manual test HIGH finding with no IP data",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
         "ProductName": "Security Hub",
         "Resources": [
           {
@@ -323,10 +547,13 @@ aws lambda invoke \
             "Type": "AwsS3Bucket"
           }
         ],
-        "Id": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "ProductArn": "<REAL-PRODUCT-ARN>",
-        "Severity": { "Label": "HIGH" },
-        "Workflow": { "Status": "NEW" },
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "HIGH"
+        },
+        "Workflow": {
+          "Status": "NEW"
         }
       }
     ]
@@ -335,67 +562,64 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
+%%%
+
+### Expected CLI Output
+
+%%%json
 {
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
 }
-{"statusCode": 200, "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"}
-```
+%%%
 
-##### Confirm Absense of Write to Security Hub Finding
+Expected Lambda response body pattern:
 
-Run the following from the CLI:
-```bash
-aws securityhub get-findings \
-  --filters '{
-    "Id": [
-      {
-        "Value": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "Comparison": "EQUALS"
-      }
-    ]
-  }' \
-  --query 'Findings[].Note'
-```
-Expected Outcome:
-```json
-[]
-```
-> NOTE: You can also confirm this via the AWS console by navigating to the Security Hub module, opening the referenced Security Hub finding, and checking the 'History' tab for 'Note Added'
+%%%json
+{
+  "statusCode": 200,
+  "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"
+}
+%%%
 
-### TEST 5 -- HIGH FINDING WITH INVALID SECURITY HUB IDENTIFIERS
-#### Expected Outcome
-* Lambda executes
-* No IP addresses are enriched
-* No SNS message is sent
-* No Security Hub writeback performed
-* No errors in logs
+---
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+## Test 5 - Finding with Invalid Security Hub Identifiers
+
+### Purpose
+
+Validate that enrichment still executes when public IPs are present, but Security Hub writeback fails safely or is skipped when finding identifiers are invalid.
+
+### Expected Outcome
+
+- Lambda executes.
+- Public IPs may still be enriched.
+- SNS notification may still be sent if enrichment succeeds.
+- Security Hub writeback should fail safely or be skipped.
+- No unhandled Lambda failure occurs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-1",
+  "id": "test-ip-enrichment-invalid-securityhub-identifiers",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "<YOUR-ACCOUNT-ID>",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": [
       {
-        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
-        "AwsAccountId": "<YOUR-ACCOUNT-ID>",
-        "Region": "us-east-1",
+        "Title": "Manual test finding with invalid Security Hub identifiers",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
         "ProductName": "Security Hub",
         "Resources": [
           {
@@ -403,10 +627,14 @@ aws lambda invoke \
             "Type": "AwsS3Bucket"
           }
         ],
-        "Id": "arn:aws:securityhub:us-east-1:072288671186:security-control/Config.1/finding/86df343a-179d-4a02-9f65-dac5c417ab75",
-        "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
-        "Severity": { "Label": "CRITICAL" },
-        "Workflow": { "Status": "NEW" },
+        "Id": "invalid-finding-id",
+        "ProductArn": "arn:aws:securityhub:${AWS_REGION}::product/aws/securityhub",
+        "Severity": {
+          "Label": "CRITICAL"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
         "Network": {
           "SourceIpV4": "103.37.6.88"
         }
@@ -417,62 +645,57 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
+%%%
+
+### Expected CLI Output
+
+%%%json
 {
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
 }
-{"statusCode": 200, "body": "{\"message\": \"No IPs enriched\", \"resultCount\": 0}"}
-```
+%%%
 
-##### Confirm Absense of Write to Security Hub Finding
+Expected Lambda response depends on implementation.
 
-Run the following from the CLI:
-```bash
-aws securityhub get-findings \
-  --filters '{
-    "Id": [
-      {
-        "Value": "<REAL-SECURITY-HUB-FINDING-ID>",
-        "Comparison": "EQUALS"
-      }
-    ]
-  }' \
-  --query 'Findings[].Note'
-```
-Expected Outcome:
-```json
-[]
-```
-> NOTE: You can also confirm this via the AWS console by navigating to the Security Hub module, opening the referenced Security Hub finding, and checking the 'History' tab for 'Note Added'
+Acceptable outcomes:
 
-### TEST 6 -- EMPTY FINDINGS ARRAY
+- Enrichment completes and Security Hub writeback is skipped.
+- Enrichment completes and Security Hub writeback logs a handled warning.
+- Lambda returns a controlled error response without modifying any Security Hub finding.
 
-#### Expected Outcome
-* Lambda executes
-* Lambda returns a response indicating no findings were present
-* No SNS message is sent
-* No Security Hub writeback performed
-* No errors in logs
+---
 
-#### Manual Event via AWS CLI:
-Run the following from the CLI:
-```bash
-export AWS_PAGER="" # Prevents AWS CLI from launching 'less'
+## Test 6 - Empty Findings Array
+
+### Purpose
+
+Validate that the Lambda handles an event with no findings safely.
+
+### Expected Outcome
+
+- Lambda executes.
+- Lambda returns a response indicating no findings were present.
+- No SNS message is sent.
+- No Security Hub writeback is performed.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
 aws lambda invoke \
-  --function-name ip-enrichment \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
   --cli-binary-format raw-in-base64-out \
   --payload "$(cat <<EOF
 {
   "version": "0",
-  "id": "test-event-7",
+  "id": "test-ip-enrichment-empty-findings",
   "detail-type": "Security Hub Findings - Imported",
   "source": "aws.securityhub",
-  "account": "072288671186",
+  "account": "${ACCOUNT_ID}",
   "time": "2026-03-02T00:00:00Z",
-  "region": "us-east-1",
+  "region": "${AWS_REGION}",
   "detail": {
     "findings": []
   }
@@ -480,12 +703,335 @@ aws lambda invoke \
 EOF
 )" \
 response.json && cat response.json && rm response.json
-```
-Expected output:
-```json
+%%%
+
+### Expected CLI Output
+
+%%%json
 {
-    "StatusCode": 200,
-    "ExecutedVersion": "$LATEST"
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
 }
-{"statusCode": 400, "body": "{\"message\": \"No findings in event\"}"}
-```
+%%%
+
+Expected Lambda response body pattern:
+
+%%%json
+{
+  "statusCode": 400,
+  "body": "{\"message\": \"No findings in event\"}"
+}
+%%%
+
+---
+
+## Test 7 - Multiple Public IPs in Product Fields
+
+### Purpose
+
+Validate that the Lambda can extract multiple public IP addresses embedded in finding fields outside the `Network` object.
+
+### Expected Outcome
+
+- Lambda executes successfully.
+- Multiple public IP addresses are extracted.
+- IP reputation data is retrieved.
+- SNS notification is sent.
+- Result count reflects the number of enriched public IPs, subject to configured limits.
+- No errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
+aws lambda invoke \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat <<EOF
+{
+  "version": "0",
+  "id": "test-ip-enrichment-multiple-productfield-ips",
+  "detail-type": "Security Hub Findings - Imported",
+  "source": "aws.securityhub",
+  "account": "${ACCOUNT_ID}",
+  "time": "2026-03-02T00:00:00Z",
+  "region": "${AWS_REGION}",
+  "detail": {
+    "findings": [
+      {
+        "Title": "Manual test finding with multiple public IPs in product fields",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
+        "ProductName": "Security Hub",
+        "Resources": [
+          {
+            "Id": "arn:aws:s3:::example-bucket",
+            "Type": "AwsS3Bucket"
+          }
+        ],
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "HIGH"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
+        "ProductFields": {
+          "source": "connection observed from 8.8.8.8",
+          "destination": "secondary connection observed from 1.1.1.1",
+          "other": "additional activity from 103.37.6.88"
+        }
+      }
+    ]
+  }
+}
+EOF
+)" \
+response.json && cat response.json && rm response.json
+%%%
+
+### Expected CLI Output
+
+%%%json
+{
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
+}
+%%%
+
+---
+
+## Test 8 - Duplicate IP Addresses
+
+### Purpose
+
+Validate that duplicate public IP addresses do not cause duplicate enrichment results beyond the Lambda's intended behavior.
+
+### Expected Outcome
+
+- Lambda executes successfully.
+- Duplicate IPs are handled safely.
+- SNS notification is sent if enrichment succeeds.
+- No unhandled errors appear in CloudWatch Logs.
+
+### Manual Event via AWS CLI
+
+%%%bash
+aws lambda invoke \
+  --region "${AWS_REGION}" \
+  --function-name "${FUNCTION_NAME}" \
+  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat <<EOF
+{
+  "version": "0",
+  "id": "test-ip-enrichment-duplicate-ips",
+  "detail-type": "Security Hub Findings - Imported",
+  "source": "aws.securityhub",
+  "account": "${ACCOUNT_ID}",
+  "time": "2026-03-02T00:00:00Z",
+  "region": "${AWS_REGION}",
+  "detail": {
+    "findings": [
+      {
+        "Title": "Manual test finding with duplicate public IPs",
+        "AwsAccountId": "${ACCOUNT_ID}",
+        "Region": "${AWS_REGION}",
+        "ProductName": "Security Hub",
+        "Resources": [
+          {
+            "Id": "arn:aws:s3:::example-bucket",
+            "Type": "AwsS3Bucket"
+          }
+        ],
+        "Id": "${REAL_SECURITY_HUB_FINDING_ID}",
+        "ProductArn": "${REAL_PRODUCT_ARN}",
+        "Severity": {
+          "Label": "HIGH"
+        },
+        "Workflow": {
+          "Status": "NEW"
+        },
+        "Network": {
+          "SourceIpV4": "8.8.8.8"
+        },
+        "ProductFields": {
+          "source": "duplicate connection from 8.8.8.8 observed"
+        }
+      }
+    ]
+  }
+}
+EOF
+)" \
+response.json && cat response.json && rm response.json
+%%%
+
+### Expected CLI Output
+
+%%%json
+{
+  "StatusCode": 200,
+  "ExecutedVersion": "$LATEST"
+}
+%%%
+
+---
+
+# EventBridge / Security Hub Integration Validation
+
+Direct Lambda invocation confirms function behavior, but it does not validate the full production event path.
+
+Use this section to validate the event-driven workflow.
+
+## Integration Path
+
+%%%text
+Security Hub Finding
+    |
+    v
+Default EventBridge Bus
+    |
+    v
+EventBridge Rule
+    |
+    v
+IP Enrichment Lambda
+    |
+    v
+AbuseIPDB Lookup
+    |
+    +--> SNS Notification
+    |
+    +--> Optional Security Hub Note Writeback
+%%%
+
+## Expected Integration Behavior
+
+When a qualifying Security Hub finding is imported:
+
+- EventBridge matches the finding.
+- The IP Enrichment Lambda is invoked.
+- Public IPs are extracted from the finding.
+- Public IPs are enriched.
+- SNS notification is sent.
+- If enabled, Security Hub note writeback occurs.
+- CloudWatch Logs show successful execution.
+
+---
+
+# Post-Test Validation
+
+After running tests, confirm:
+
+- Lambda invocation succeeded.
+- CloudWatch Logs show expected behavior.
+- SNS notification was received when public IPs were enriched.
+- Security Hub note writeback occurred only when expected.
+- Private IPs were ignored.
+- Empty findings were handled safely.
+- Invalid Security Hub identifiers did not cause uncontrolled failures.
+
+---
+
+# Troubleshooting
+
+## Lambda invocation fails
+
+Check:
+
+- Function name is correct.
+- AWS CLI is authenticated to the target account.
+- Region is correct.
+- Caller has `lambda:InvokeFunction`.
+- Lambda exists in the selected environment.
+
+---
+
+## No IPs are enriched
+
+Check:
+
+- The event contains public IP addresses.
+- IPs are not private, loopback, link-local, or otherwise non-public.
+- IP extraction logic supports the field where the IP appears.
+- `MAX_IPS_EXTRACTED` and `MAX_IPS_PER_EVENT` are not set too low.
+
+---
+
+## AbuseIPDB lookup fails
+
+Check:
+
+- `THREAT_INTEL_SECRET_ARN` is configured.
+- The secret exists in Secrets Manager.
+- The secret contains a valid AbuseIPDB API key.
+- Lambda execution role can read the secret.
+- Lambda has network egress to reach AbuseIPDB.
+- Network Firewall, NAT, and route tables allow required outbound connectivity.
+
+---
+
+## SNS notification is not received
+
+Check:
+
+- `SNS_TOPIC_ARN` is configured.
+- SNS topic exists.
+- Lambda execution role has `sns:Publish`.
+- Email subscription is confirmed.
+- SNS topic KMS permissions allow Lambda usage.
+
+---
+
+## Security Hub writeback does not occur
+
+Check:
+
+- `WRITE_TO_SECURITYHUB=true`.
+- The test uses a real Security Hub finding ID.
+- The test uses the correct ProductArn.
+- Lambda execution role has `securityhub:BatchUpdateFindings`.
+- Security Hub is enabled in the target account and region.
+- Finding belongs to the same account and region being tested.
+
+---
+
+## KMS AccessDenied
+
+Check:
+
+- Lambda execution role has access to the required KMS key.
+- KMS key policy allows IAM delegation.
+- Secrets Manager secret encryption allows Lambda access.
+- SNS topic encryption allows Lambda access.
+- The relevant CMK ARNs were passed into the IAM policy module.
+
+---
+
+## Lambda times out
+
+Check:
+
+- Lambda has outbound internet access if calling AbuseIPDB.
+- NAT Gateway and route tables are configured correctly.
+- AWS Network Firewall rules allow the required outbound request.
+- DNS resolution is working.
+- Lambda timeout is long enough for external API calls.
+
+---
+
+# Summary
+
+These tests validate the IP Enrichment Lambda in the context of the full `tf-secure-baseline` platform.
+
+They confirm that:
+
+- Public IPv4 addresses are extracted and enriched.
+- Public IPv6 addresses are extracted and enriched.
+- Private IP addresses are ignored.
+- Findings without IP data are handled safely.
+- Empty findings are handled safely.
+- Security Hub writeback works when valid identifiers are supplied.
+- SNS notifications are sent when enrichment occurs.
+- The function fits into the broader Security Hub, EventBridge, SNS, KMS, Secrets Manager, and multi-account architecture.

--- a/docs/lambda_tests/ip_enrichment.md
+++ b/docs/lambda_tests/ip_enrichment.md
@@ -742,11 +742,14 @@ This test confirms the Lambda can still enrich public IP indicators even when th
 
 ### Expected Outcome
 
+### Expected Outcome
+
 - Lambda executes successfully.
-- Multiple public IP addresses are extracted.
+- Public IP addresses are extracted from `ProductFields`.
 - IP reputation data is retrieved.
 - SNS notification is sent.
-- Result count reflects the number of enriched public IPs, subject to configured limits.
+- Result count reflects the number of unique enriched public IPs, subject to configured limits.
+- If valid Security Hub identifiers are supplied and `WRITE_TO_SECURITYHUB=true`, a note is written back to the finding.
 - No errors appear in CloudWatch Logs.
 
 ### Manual Event via AWS CLI

--- a/modules/automation/lambda/ip_enrichment.py
+++ b/modules/automation/lambda/ip_enrichment.py
@@ -211,6 +211,25 @@ def _is_valid_securityhub_finding_id(finding_id: Any) -> bool:
     if not finding_id:
         return False
 
+    if not finding_id.startswith("arn:"):
+        return False
+    if "/finding/" not in finding_id:
+        return False
+
+    return True
+
+def _is_valid_securityhub_product_arn(product_arn: Any) -> bool:
+    """Basic structural validation for Security Hub ProductArn values"""
+    if not isinstance(product_arn, str):
+        return False
+
+    product_arn = product_arn.strip()
+    if not product_arn:
+        return False
+
+    # Security Hub product ARN is ARN-like and typically contains ":product/"
+    return product_arn.startswith("arn:") and ":product/" in product_arn
+
 def _abuse_severity(score: Optional[int]) -> str:
     if not isinstance(score, int):
         return "Unknown"
@@ -430,16 +449,9 @@ def lambda_handler(event, context):
     ]
     if invalid_finding_ids:
         logger.warning(
-            "Skipping processing due to invalid Security Hub finding ID(s): %s",
+            "One or more invalid Security Hub finding ID(s) detected. Enrichment will continue, but writeback may be skipped for invalid identifiers: %s",
             invalid_finding_ids[:5],
         )
-        return {
-            "statusCode": 400,
-            "body": json.dumps({
-                "message": "Invalid Security Hub finding ID; skipping processing",
-                "invalidFindingIds": invalid_finding_ids[:5],
-            }),
-        }
 
     api_key = _get_abuseipdb_api_key()
     if not api_key:
@@ -494,8 +506,14 @@ def lambda_handler(event, context):
             for f in findings:
                 fid = f.get("Id")
                 product_arn = f.get("ProductArn")
-                if fid and product_arn:
+                if _is_valid_securityhub_finding_id(fid) and _is_valid_securityhub_product_arn(product_arn):
                     identifiers.append({"Id": fid, "ProductArn": product_arn})
+                else:
+                    logger.warning(
+                        "Skipping invalid Security Hub writeback identifier pair (Id=%s, ProductArn=%s)",
+                        fid,
+                        product_arn,
+                    )
 
             if not identifiers:
                 logger.warning("No valid finding identifers; skipping Security Hub writeback.")

--- a/modules/automation/lambda/ip_enrichment.py
+++ b/modules/automation/lambda/ip_enrichment.py
@@ -321,7 +321,8 @@ def format_enrichment_message(finding_metadata: Dict[str, str], enriched: List[D
     lines.append("🧠 IP Threat Intel IP Enrichment")
     lines.append("")
     lines.append(f"Total IPs enriched: {len(enriched)} (public-only)")
-    lines.append(f"📝 Security Hub writeback enabled: {WRITE_TO_SECURITYHUB}")
+    writeback_status = finding_metadata.get("writeback_status", str(WRITE_TO_SECURITYHUB))
+    lines.append(f"📝 Security Hub writeback enabled: {writeback_status}")
     lines.append("")
 
     for entry in enriched:
@@ -495,6 +496,26 @@ def lambda_handler(event, context):
     )
 
     finding_metadata["finding_url"] = finding_url
+
+    # Determine writeback status text for SNS message context
+    writeback_status = str(WRITE_TO_SECURITYHUB)
+    if WRITE_TO_SECURITYHUB:
+        valid_identifier_pairs = 0
+        invalid_identifier_pairs = 0
+        for f in findings:
+            fid = f.get("Id")
+            product_arn = f.get("ProductArn")
+            if _is_valid_securityhub_finding_id(fid) and _is_valid_securityhub_product_arn(product_arn):
+                valid_identifier_pairs += 1
+            else:
+                invalid_identifier_pairs += 1
+
+        if invalid_identifier_pairs > 0 and valid_identifier_pairs == 0:
+            writeback_status = "True (writeback skipped: invalid Security Hub identifier(s))"
+        elif invalid_identifier_pairs > 0:
+            writeback_status = "True (some identifier pairs invalid; skipped for those findings)"
+
+    finding_metadata["writeback_status"] = writeback_status
 
     subject = f"🧠 [{finding_metadata['severity']}] IP Threat Intel Report: ({len(enriched)}) IP{'s' if len(enriched) != 1 else ''} Enriched"   
     message = format_enrichment_message(finding_metadata, enriched)

--- a/modules/automation/lambda/ip_enrichment.py
+++ b/modules/automation/lambda/ip_enrichment.py
@@ -423,6 +423,24 @@ def lambda_handler(event, context):
         logger.warning("No findings in event.")
         return {"statusCode": 400, "body": json.dumps({"message": "No findings in event"})}
     
+    invalid_finding_ids = [
+        f.get("Id")
+        for f in findings
+        if not _is_valid_securityhub_finding_id(f.get("Id"))
+    ]
+    if invalid_finding_ids:
+        logger.warning(
+            "Skipping processing due to invalid Security Hub finding ID(s): %s",
+            invalid_finding_ids[:5],
+        )
+        return {
+            "statusCode": 400,
+            "body": json.dumps({
+                "message": "Invalid Security Hub finding ID; skipping processing",
+                "invalidFindingIds": invalid_finding_ids[:5],
+            }),
+        }
+
     api_key = _get_abuseipdb_api_key()
     if not api_key:
         return {"statusCode": 500, "body": json.dumps({"message": "Missing AbuseIPDB API key"})}

--- a/modules/automation/lambda/ip_enrichment.py
+++ b/modules/automation/lambda/ip_enrichment.py
@@ -202,6 +202,15 @@ def _extract_abuse_categories(result: Dict[str, Any]) -> List[str]:
         for category_id in sorted(category_ids)
     ]
 
+def _is_valid_securityhub_finding_id(finding_id: Any) -> bool:
+    """Basic structural validation for Security Hub finding IDs"""
+    if not isinstance(finding_id, str):
+        return False
+    
+    finding_id = finding_id.strip()
+    if not finding_id:
+        return False
+
 def _abuse_severity(score: Optional[int]) -> str:
     if not isinstance(score, int):
         return "Unknown"


### PR DESCRIPTION
This PR addresses the following issues:

fix: Modify IP Enrichment Lambda to evaluate if Security Hub findings are valid, reference that in the report, and do not write to sechub if invalid #303
Refine ip_enrichment.md Lambda test file #304 