### PR TITLE
docs: Create ISO 27001 control mapping document

### DIFF
--- a/docs/assurance/iso27001-control-mapping.md
+++ b/docs/assurance/iso27001-control-mapping.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document describes how `tf-secure-baseline` infrastructure controls align with selected ISO/IEC 27001:2022 Annex A control themes.
+This document describes how `tf-secure-baseline` infrastructure controls align with selected **ISO/IEC 27001:2022 Annex A** control themes.
 
 The baseline is designed to support ISO 27001 readiness by implementing technical safeguards across AWS environments that handle sensitive data, such as PII.
 


### PR DESCRIPTION
This PR addresses the following issue:

Create 'iso27001-control-mapping.md' under the 'docs/assurance/' directory (Closes #326)