### PR TITLE
refactor: Refactor IAM module resources with 'jsonencode()' to use aws_iam_policy_document data blocks instead

### DIFF
--- a/modules/iam/backup.tf
+++ b/modules/iam/backup.tf
@@ -34,10 +34,10 @@ resource "aws_iam_role" "backup" {
 # ATTACH AWS-MANAGED BACKUP POLICIES
 resource "aws_iam_role_policy_attachment" "backup" {
   role       = aws_iam_role.backup.name
-  policy_arn = data.aws_iam_policy.backup.arn
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
 }
 
 resource "aws_iam_role_policy_attachment" "backup_restore" {
   role       = aws_iam_role.backup.name
-  policy_arn = data.aws_iam_policy.backup_restore.arn
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
 }

--- a/modules/iam/backup.tf
+++ b/modules/iam/backup.tf
@@ -1,15 +1,5 @@
 # BACKUP-RELATED IAM RESOURCES
 
-# PULL THE AWS-MANAGED BACKUP ROLE POLICY FOR BACKUP CREATION
-data "aws_iam_policy" "backup" {
-  name = "AWSBackupServiceRolePolicyForBackup"
-}
-
-# PULL THE AWS-MANAGED BACKUP ROLE POLICY FOR BACKUP RESTORATION
-data "aws_iam_policy" "backup_restore" {
-  name = "AWSBackupServiceRolePolicyForRestores"
-}
-
 # AWS BACKUP SERVICE TRUST POLICY
 data "aws_iam_policy_document" "backup_assume_role" {
   statement {

--- a/modules/iam/backup.tf
+++ b/modules/iam/backup.tf
@@ -10,20 +10,25 @@ data "aws_iam_policy" "backup_restore" {
   name = "AWSBackupServiceRolePolicyForRestores"
 }
 
+# AWS BACKUP SERVICE TRUST POLICY
+data "aws_iam_policy_document" "backup_assume_role" {
+  statement {
+    sid = "AllowAWSBackupServiceAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
 # AWS BACKUP SERVICE ROLE
 resource "aws_iam_role" "backup" {
   name = "${var.name_prefix}-backup-role"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "backup.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.backup_assume_role.json
 }
 
 # ATTACH AWS-MANAGED BACKUP POLICIES

--- a/modules/iam/backup.tf
+++ b/modules/iam/backup.tf
@@ -3,12 +3,12 @@
 # AWS BACKUP SERVICE TRUST POLICY
 data "aws_iam_policy_document" "backup_assume_role" {
   statement {
-    sid = "AllowAWSBackupServiceAssumeRole"
-    effect = "Allow"
+    sid     = "AllowAWSBackupServiceAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["backup.amazonaws.com"]
     }
   }

--- a/modules/iam/break_glass.tf
+++ b/modules/iam/break_glass.tf
@@ -7,19 +7,19 @@
 
 data "aws_iam_policy_document" "break_glass_admin_assume_role" {
   statement {
-    sid = "AllowEmergencyAssumeRoleWithMFA"
-    effect = "Allow"
+    sid     = "AllowEmergencyAssumeRoleWithMFA"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = var.break_glass_trusted_principal_arns
     }
 
     condition {
-      test = "Bool"
+      test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
-      values = ["true"]
+      values   = ["true"]
     }
   }
 }

--- a/modules/iam/break_glass.tf
+++ b/modules/iam/break_glass.tf
@@ -5,6 +5,7 @@
 # It should only be used if IAM Identity Center (SSO) is unavailable.
 # All usage should be monitored and audited.
 
+# BREAK-GLASS ADMIN TRUST POLICY
 data "aws_iam_policy_document" "break_glass_admin_assume_role" {
   statement {
     sid     = "AllowEmergencyAssumeRoleWithMFA"

--- a/modules/iam/break_glass.tf
+++ b/modules/iam/break_glass.tf
@@ -5,28 +5,31 @@
 # It should only be used if IAM Identity Center (SSO) is unavailable.
 # All usage should be monitored and audited.
 
+data "aws_iam_policy_document" "break_glass_admin_assume_role" {
+  statement {
+    sid = "AllowEmergencyAssumeRoleWithMFA"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = var.break_glass_trusted_principal_arns
+    }
+
+    condition {
+      test = "Bool"
+      variable = "aws:MultiFactorAuthPresent"
+      values = ["true"]
+    }
+  }
+}
+
+# BREAK-GLASS ADMIN ROLE
 resource "aws_iam_role" "break_glass_admin" {
   name        = "${var.name_prefix}-BreakGlass-Admin"
   description = "Emergency-only administrator role to be used if IAM Identity Center access is unavailable"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowEmergencyAssumeRoleWithMFA"
-        Effect = "Allow"
-        Principal = {
-          AWS = var.break_glass_trusted_principal_arns
-        }
-        Action = "sts:AssumeRole"
-        Condition = {
-          Bool = {
-            "aws:MultiFactorAuthPresent" = "true"
-          }
-        }
-      }
-    ]
-  })
+  assume_role_policy = data.aws_iam_policy_document.break_glass_admin_assume_role.json
 
   tags = {
     Name        = "${var.name_prefix}-BreakGlass-Admin"

--- a/modules/iam/config.tf
+++ b/modules/iam/config.tf
@@ -61,5 +61,5 @@ resource "aws_iam_role_policy" "s3_public_remediation" {
   name = "${var.name_prefix}-S3PublicAccessBlockRemediation"
   role = aws_iam_role.config_remediation.id
 
-  policy = data.aws_iam_policy_document.config_remediation_assume_role.json
+  policy = data.aws_iam_policy_document.s3_public_remediation.json
 }

--- a/modules/iam/config.tf
+++ b/modules/iam/config.tf
@@ -9,25 +9,30 @@ resource "aws_iam_service_linked_role" "config" {
   aws_service_name = "config.amazonaws.com"
 }
 
+# CONFIG REMEDIATION TRUST POLICY
+data "aws_iam_policy_document" "config_remediation_assume_role" {
+  statement {
+    sid = "AllowSSMAssumeRoleFromAccount"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [var.account_id]
+    }
+  }
+}
+
 # CONFIG REMEDIATION ROLE
 resource "aws_iam_role" "config_remediation" {
   name = "${var.name_prefix}-ConfigRemediationRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "ssm.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-      Condition = {
-        StringEquals = {
-          "aws:SourceAccount" = var.account_id
-        }
-      }
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.config_remediation_assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "config_ssm_automation" {

--- a/modules/iam/config.tf
+++ b/modules/iam/config.tf
@@ -41,23 +41,25 @@ resource "aws_iam_role_policy_attachment" "config_ssm_automation" {
 }
 
 ## CONFIG REMEDIATION S3 PUBLIC ACCESS BLOCK POLICY
+data "aws_iam_policy_document" "s3_public_remediation" {
+  statement {
+    sid = "AllowS3PublicAccessBlockRemediation"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketPublicAccessBlock",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:GetBucketPolicy",
+      "s3:PutBucketPolicy"
+    ]
+
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_role_policy" "s3_public_remediation" {
   name = "${var.name_prefix}-S3PublicAccessBlockRemediation"
   role = aws_iam_role.config_remediation.id
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetBucketPublicAccessBlock",
-          "s3:PutBucketPublicAccessBlock",
-          "s3:GetBucketPolicy",
-          "s3:PutBucketPolicy"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.config_remediation_assume_role.json
 }

--- a/modules/iam/config.tf
+++ b/modules/iam/config.tf
@@ -12,26 +12,26 @@ resource "aws_iam_service_linked_role" "config" {
 # CONFIG REMEDIATION TRUST POLICY
 data "aws_iam_policy_document" "config_remediation_assume_role" {
   statement {
-    sid = "AllowSSMAssumeRoleFromAccount"
-    effect = "Allow"
+    sid     = "AllowSSMAssumeRoleFromAccount"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["ssm.amazonaws.com"]
     }
 
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "aws:SourceAccount"
-      values = [var.account_id]
+      values   = [var.account_id]
     }
   }
 }
 
 # CONFIG REMEDIATION ROLE
 resource "aws_iam_role" "config_remediation" {
-  name = "${var.name_prefix}-ConfigRemediationRole"
+  name               = "${var.name_prefix}-ConfigRemediationRole"
   assume_role_policy = data.aws_iam_policy_document.config_remediation_assume_role.json
 }
 

--- a/modules/iam/config.tf
+++ b/modules/iam/config.tf
@@ -43,7 +43,7 @@ resource "aws_iam_role_policy_attachment" "config_ssm_automation" {
 ## CONFIG REMEDIATION S3 PUBLIC ACCESS BLOCK POLICY
 data "aws_iam_policy_document" "s3_public_remediation" {
   statement {
-    sid = "AllowS3PublicAccessBlockRemediation"
+    sid    = "AllowS3PublicAccessBlockRemediation"
     effect = "Allow"
 
     actions = [

--- a/modules/iam/ec2.tf
+++ b/modules/iam/ec2.tf
@@ -3,12 +3,12 @@
 # EC2 TRUST POLICY
 data "aws_iam_policy_document" "ec2_assume_role" {
   statement {
-    sid = "AllowEC2AssumeRole"
-    effect = "Allow"
+    sid     = "AllowEC2AssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = "ec2.amazonaws.com"
     }
   }
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "ec2_assume_role" {
 
 ## EC2 ROLE
 resource "aws_iam_role" "ec2_role" {
-  name = "${var.name_prefix}-ec2_compute_role"
+  name               = "${var.name_prefix}-ec2_compute_role"
   assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
 }
 

--- a/modules/iam/ec2.tf
+++ b/modules/iam/ec2.tf
@@ -1,18 +1,23 @@
-# EC2 Roles and Policies
-## EC2 Role
+# EC2 ROLES AND POLICIES
+
+# EC2 TRUST POLICY
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    sid = "AllowEC2AssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = "ec2.amazonaws.com"
+    }
+  }
+}
+
+## EC2 ROLE
 resource "aws_iam_role" "ec2_role" {
   name = "${var.name_prefix}-ec2_compute_role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "ec2.amazonaws.com"
-      }
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
 }
 
 ## Allow SSM to access EC2 resources

--- a/modules/iam/ec2.tf
+++ b/modules/iam/ec2.tf
@@ -9,7 +9,7 @@ data "aws_iam_policy_document" "ec2_assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = "ec2.amazonaws.com"
+      identifiers = ["ec2.amazonaws.com"]
     }
   }
 }

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -35,6 +35,7 @@ resource "aws_iam_role" "lambda_ec2_isolation" {
   tags = {
     Name      = "Lambda-EC2-Isolation-Role"
     Terraform = "true"
+    Environment = var.environment
   }
 }
 
@@ -115,6 +116,7 @@ resource "aws_iam_role" "lambda_ec2_rollback" {
   tags = {
     Name      = "Lambda-EC2-Rollback-Role"
     Terraform = "true"
+    Environment = var.environment
   }
 }
 
@@ -193,6 +195,7 @@ resource "aws_iam_role" "lambda_ip_enrichment" {
   tags = {
     Name      = "Lambda-IP-Enrichment-Role"
     Terraform = "true"
+    Environment = var.environment
   }
 }
 

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -103,17 +103,7 @@ resource "aws_iam_role_policy_attachment" "ec2_isolation_xray_attach" {
 ### EC2 ROLLBACK LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_rollback" {
   name = "${var.name_prefix}-lambda-ec2-rollback"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "lambda.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
 ### EC2 ROLLBACK IAM POLICY

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -34,45 +34,47 @@ resource "aws_iam_role" "lambda_ec2_isolation" {
 }
 
 ### EC2 ISOLATION IAM POLICY
+data "aws_iam_policy_document" "lambda_ec2_isolation" {
+  statement {
+    sid = "AllowEC2IsolationActions"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:DescribeSecurityGroups",
+      "ec2:CreateTags",
+      "ec2:CreateSnapshot"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowSNSSecurityAlerts"
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+
+    resources = [var.secops_topic_arn]
+  }
+
+  statement {
+    sid = "AllowLogsKMSUsage"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [var.logs_cmk_arn]
+  }
+}
+
 resource "aws_iam_policy" "lambda_ec2_isolation" {
   name = "${var.name_prefix}-lambda-ec2-isolation"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-
-      # CUSTOM POLICY FOR EC2 CONTROL
-      {
-        Effect = "Allow"
-        Action = [
-          "ec2:DescribeInstances",
-          "ec2:ModifyInstanceAttribute",
-          "ec2:DescribeSecurityGroups",
-          "ec2:CreateTags",
-          "ec2:CreateSnapshot"
-        ]
-        Resource = "*"
-      },
-      # ALLOW LAMBDA TO CALL SNS
-      {
-        Effect = "Allow",
-        Action = [
-          "sns:Publish"
-        ]
-        Resource = var.secops_topic_arn
-      },
-      # ALLOW USE OF LOGS KMS KEY (USED FOR SNS)
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:GenerateDataKey*",
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ]
-        Resource = var.logs_cmk_arn
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.lambda_ec2_isolation
 }
 
 ### ATTACH EC2 ISOLATION POLICY TO EC2 ISOLATION EXECUTION ROLE

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -147,10 +147,9 @@ data "aws_iam_policy_document" "lambda_ec2_rollback" {
     sid    = "AllowLogsKMSUsage"
     effect = "Allow"
     actions = [
-      "ec2:DescribeInstances",
-      "ec2:ModifyInstanceAttribute",
-      "ec2:DescribeSecurityGroups",
-      "ec2:CreateTags"
+      "kms:GenerateDataKey*",
+      "kms:Decrypt",
+      "kms:DescribeKey"
     ]
 
     resources = [var.logs_cmk_arn]

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -173,9 +173,9 @@ resource "aws_iam_role_policy_attachment" "ec2_rollback_xray_attach" {
 ## IP ENRICHMENT LAMBDA
 ### IP ENRICHMENT LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ip_enrichment" {
-  name = "${var.name_prefix}-lambda-ip-enrichment"
+  name               = "${var.name_prefix}-lambda-ip-enrichment"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
-  
+
   tags = {
     Name      = "Lambda-IP-Enrichment-Role"
     Terraform = "true"

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -111,7 +111,7 @@ resource "aws_iam_role" "lambda_ec2_rollback" {
 ### EC2 ROLLBACK IAM POLICY
 data "aws_iam_policy_document" "lambda_ec2_rollback" {
   statement {
-    sid = "AllowEC2RollbackActions"
+    sid    = "AllowEC2RollbackActions"
     effect = "Allow"
     actions = [
       "ec2:DescribeInstances",
@@ -124,15 +124,15 @@ data "aws_iam_policy_document" "lambda_ec2_rollback" {
   }
 
   statement {
-    sid = "AllowSNSSecurityAlerts"
-    effect = "Allow"
+    sid     = "AllowSNSSecurityAlerts"
+    effect  = "Allow"
     actions = ["sns:Publish"]
 
     resources = [var.secops_topic_arn]
   }
 
   statement {
-    sid = "AllowLogsKMSUsage"
+    sid    = "AllowLogsKMSUsage"
     effect = "Allow"
     actions = [
       "ec2:DescribeInstances",
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "lambda_ec2_rollback" {
 }
 
 resource "aws_iam_policy" "lambda_ec2_rollback" {
-  name = "${var.name_prefix}-lambda-rollback-policy"
+  name   = "${var.name_prefix}-lambda-rollback-policy"
   policy = data.aws_iam_policy_document.lambda_ec2_rollback.json
 }
 

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -102,7 +102,7 @@ resource "aws_iam_role_policy_attachment" "ec2_isolation_xray_attach" {
 ## EC2 ROLLBACK LAMBDA
 ### EC2 ROLLBACK LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_rollback" {
-  name = "${var.name_prefix}-lambda-ec2-rollback"
+  name               = "${var.name_prefix}-lambda-ec2-rollback"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -36,7 +36,7 @@ resource "aws_iam_role" "lambda_ec2_isolation" {
 ### EC2 ISOLATION IAM POLICY
 data "aws_iam_policy_document" "lambda_ec2_isolation" {
   statement {
-    sid = "AllowEC2IsolationActions"
+    sid    = "AllowEC2IsolationActions"
     effect = "Allow"
     actions = [
       "ec2:DescribeInstances",
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
   }
 
   statement {
-    sid = "AllowSNSSecurityAlerts"
+    sid    = "AllowSNSSecurityAlerts"
     effect = "Allow"
     actions = [
       "sns:Publish"
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
   }
 
   statement {
-    sid = "AllowLogsKMSUsage"
+    sid    = "AllowLogsKMSUsage"
     effect = "Allow"
     actions = [
       "kms:GenerateDataKey*",
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
 }
 
 resource "aws_iam_policy" "lambda_ec2_isolation" {
-  name = "${var.name_prefix}-lambda-ec2-isolation"
+  name   = "${var.name_prefix}-lambda-ec2-isolation"
   policy = data.aws_iam_policy_document.lambda_ec2_isolation
 }
 

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -174,17 +174,8 @@ resource "aws_iam_role_policy_attachment" "ec2_rollback_xray_attach" {
 ### IP ENRICHMENT LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ip_enrichment" {
   name = "${var.name_prefix}-lambda-ip-enrichment"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "lambda.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  
   tags = {
     Name      = "Lambda-IP-Enrichment-Role"
     Terraform = "true"

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -188,7 +188,7 @@ resource "aws_iam_role" "lambda_ip_enrichment" {
 
 data "aws_iam_policy_document" "lambda_ip_enrichment" {
   statement {
-    sid = "AllowThreatIntelSecretRead"
+    sid    = "AllowThreatIntelSecretRead"
     effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",
@@ -199,15 +199,15 @@ data "aws_iam_policy_document" "lambda_ip_enrichment" {
   }
 
   statement {
-    sid = "AllowSNSSecurityAlerts"
-    effect = "Allow"
+    sid     = "AllowSNSSecurityAlerts"
+    effect  = "Allow"
     actions = ["sns:Publish"]
 
     resources = [var.secops_topic_arn]
   }
 
   statement {
-    sid = "AllowLogsKMSUsage"
+    sid    = "AllowLogsKMSUsage"
     effect = "Allow"
     actions = [
       "kms:GenerateDataKey*",
@@ -219,14 +219,14 @@ data "aws_iam_policy_document" "lambda_ip_enrichment" {
   }
 
   statement {
-    sid = "AllowSecurityHubFindingUpdates"
-    effect = "Allow"
-    actions = ["securityhub:BatchUpdateFindings"]
+    sid       = "AllowSecurityHubFindingUpdates"
+    effect    = "Allow"
+    actions   = ["securityhub:BatchUpdateFindings"]
     resources = ["*"]
   }
 
   statement {
-    sid = "AllowSecretsManagerKMSUsage"
+    sid    = "AllowSecretsManagerKMSUsage"
     effect = "Allow"
     actions = [
       "kms:Decrypt",
@@ -240,7 +240,7 @@ data "aws_iam_policy_document" "lambda_ip_enrichment" {
 resource "aws_iam_policy" "lambda_ip_enrichment" {
   name        = "${var.name_prefix}-lambda-ip-enrichment-policy"
   description = "Permissions for IP Enrichment Lambda"
-  policy = data.aws_iam_policy_document.lambda_ip_enrichment.json
+  policy      = data.aws_iam_policy_document.lambda_ip_enrichment.json
 }
 
 ### ATTACH LAMBDA_IP_ENRICHMENT IAM POLICY TO IP ENRICHMENT LAMBDA

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -109,43 +109,45 @@ resource "aws_iam_role" "lambda_ec2_rollback" {
 }
 
 ### EC2 ROLLBACK IAM POLICY
+data "aws_iam_policy_document" "lambda_ec2_rollback" {
+  statement {
+    sid = "AllowEC2RollbackActions"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:DescribeSecurityGroups",
+      "ec2:CreateTags"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowSNSSecurityAlerts"
+    effect = "Allow"
+    actions = ["sns:Publish"]
+
+    resources = [var.secops_topic_arn]
+  }
+
+  statement {
+    sid = "AllowLogsKMSUsage"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:DescribeSecurityGroups",
+      "ec2:CreateTags"
+    ]
+
+    resources = [var.logs_cmk_arn]
+  }
+}
+
 resource "aws_iam_policy" "lambda_ec2_rollback" {
   name = "${var.name_prefix}-lambda-rollback-policy"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      # CUSTOM POLICY FOR EC2 CONTROL
-      {
-        Effect = "Allow"
-        Action = [
-          "ec2:DescribeInstances",
-          "ec2:ModifyInstanceAttribute",
-          "ec2:DescribeSecurityGroups",
-          "ec2:CreateTags"
-        ]
-        Resource = "*"
-      },
-      # ALLOW LAMBDA TO CALL SNS
-      {
-        Effect = "Allow"
-        Action = [
-          "sns:Publish"
-        ]
-        Resource = var.secops_topic_arn
-      },
-      # ALLOW USE OF LOGS KMS KEY (USED FOR SNS)
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:GenerateDataKey*",
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ]
-        Resource = var.logs_cmk_arn
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.lambda_ec2_rollback.json
 }
 
 ### ATTACH EC2 ROLLBACK POLICY TO EC2 ROLLBACK EXECUTION ROLE

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -186,59 +186,61 @@ resource "aws_iam_role" "lambda_ip_enrichment" {
   }
 }
 
+data "aws_iam_policy_document" "lambda_ip_enrichment" {
+  statement {
+    sid = "AllowThreatIntelSecretRead"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+
+    resources = [var.threat_intel_api_keys_arn]
+  }
+
+  statement {
+    sid = "AllowSNSSecurityAlerts"
+    effect = "Allow"
+    actions = ["sns:Publish"]
+
+    resources = [var.secops_topic_arn]
+  }
+
+  statement {
+    sid = "AllowLogsKMSUsage"
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [var.logs_cmk_arn]
+  }
+
+  statement {
+    sid = "AllowSecurityHubFindingUpdates"
+    effect = "Allow"
+    actions = ["securityhub:BatchUpdateFindings"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowSecretsManagerKMSUsage"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [var.secrets_manager_cmk_arn]
+  }
+}
+
 resource "aws_iam_policy" "lambda_ip_enrichment" {
   name        = "${var.name_prefix}-lambda-ip-enrichment-policy"
   description = "Permissions for IP Enrichment Lambda"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      # ALLOW LAMBDA TO RETRIEVE THREAT_INTEL_API_KEYS FROM SECRETS MANAGER
-      {
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue",
-          "secretsmanager:DescribeSecret"
-        ]
-        Resource = var.threat_intel_api_keys_arn
-      },
-      # PUBLISH ENRICHED ALERT TO SNS
-      {
-        Effect = "Allow"
-        Action = [
-          "sns:Publish"
-        ]
-        Resource = var.secops_topic_arn
-      },
-      # ALLOW USE OF LOGS KMS KEY (USED FOR SNS)
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:GenerateDataKey*",
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ]
-        Resource = var.logs_cmk_arn
-      },
-      # ALLOW LAMBDA TO WRITE ENRICHMENT NOTES TO FINDINGS
-      {
-        Effect = "Allow"
-        Action = [
-          "securityhub:BatchUpdateFindings"
-        ]
-        Resource = "*"
-      },
-      # ALLOW LAMBDA TO CALL SECRETS MANAGER KMS KEY
-      {
-        Effect = "Allow",
-        Action = [
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ],
-        Resource = var.secrets_manager_cmk_arn
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.lambda_ip_enrichment.json
 }
 
 ### ATTACH LAMBDA_IP_ENRICHMENT IAM POLICY TO IP ENRICHMENT LAMBDA

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -31,6 +31,11 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 resource "aws_iam_role" "lambda_ec2_isolation" {
   name               = "${var.name_prefix}-lambda-ec2-isolation-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = {
+    Name      = "Lambda-EC2-Isolation-Role"
+    Terraform = "true"
+  }
 }
 
 ### EC2 ISOLATION IAM POLICY
@@ -106,6 +111,11 @@ resource "aws_iam_role_policy_attachment" "ec2_isolation_xray_attach" {
 resource "aws_iam_role" "lambda_ec2_rollback" {
   name               = "${var.name_prefix}-lambda-ec2-rollback"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = {
+    Name      = "Lambda-EC2-Rollback-Role"
+    Terraform = "true"
+  }
 }
 
 ### EC2 ROLLBACK IAM POLICY

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 ### EC2 ISOLATION LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_isolation" {
   name               = "${var.name_prefix}-lambda-ec2-isolation-role"
-  assume_role_policy = data.aws_iam_policy_document.lambda_ec2_isolation_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
 ### EC2 ISOLATION IAM POLICY

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -13,20 +13,24 @@ data "aws_iam_policy" "lambda_xray" {
 }
 
 ## EC2 ISOLATION LAMBDA
+### EC2 ISOLATION LAMBDA TRUST POLICY
+data "aws_iam_policy_document" "lambda_ec2_isolation_assume_role" {
+  statement {
+    sid = "LambdaEC2IsolationAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
 ### EC2 ISOLATION LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_isolation" {
   name = "${var.name_prefix}-lambda-ec2-isolation-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "lambda.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.lambda_ec2_isolation_assume_role.json
 }
 
 ### EC2 ISOLATION IAM POLICY

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -16,12 +16,12 @@ data "aws_iam_policy" "lambda_xray" {
 ### EC2 ISOLATION LAMBDA TRUST POLICY
 data "aws_iam_policy_document" "lambda_ec2_isolation_assume_role" {
   statement {
-    sid = "LambdaEC2IsolationAssumeRole"
-    effect = "Allow"
+    sid     = "LambdaEC2IsolationAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
     }
   }
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation_assume_role" {
 
 ### EC2 ISOLATION LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_isolation" {
-  name = "${var.name_prefix}-lambda-ec2-isolation-role"
+  name               = "${var.name_prefix}-lambda-ec2-isolation-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_ec2_isolation_assume_role.json
 }
 

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -1,4 +1,3 @@
-
 # LAMBDA ROLES
 ## AWS-MANAGED POLICIES FOR LAMBDA LOGGING & VPC ENI ACCESS
 data "aws_iam_policy" "lambda_vpc" {

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -33,8 +33,8 @@ resource "aws_iam_role" "lambda_ec2_isolation" {
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 
   tags = {
-    Name      = "Lambda-EC2-Isolation-Role"
-    Terraform = "true"
+    Name        = "Lambda-EC2-Isolation-Role"
+    Terraform   = "true"
     Environment = var.environment
   }
 }
@@ -114,8 +114,8 @@ resource "aws_iam_role" "lambda_ec2_rollback" {
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 
   tags = {
-    Name      = "Lambda-EC2-Rollback-Role"
-    Terraform = "true"
+    Name        = "Lambda-EC2-Rollback-Role"
+    Terraform   = "true"
     Environment = var.environment
   }
 }
@@ -193,8 +193,8 @@ resource "aws_iam_role" "lambda_ip_enrichment" {
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 
   tags = {
-    Name      = "Lambda-IP-Enrichment-Role"
-    Terraform = "true"
+    Name        = "Lambda-IP-Enrichment-Role"
+    Terraform   = "true"
     Environment = var.environment
   }
 }

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -12,9 +12,8 @@ data "aws_iam_policy" "lambda_xray" {
   arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-## EC2 ISOLATION LAMBDA
-### EC2 ISOLATION LAMBDA TRUST POLICY
-data "aws_iam_policy_document" "lambda_ec2_isolation_assume_role" {
+# LAMBDA TRUST POLICY
+data "aws_iam_policy_document" "lambda_assume_role" {
   statement {
     sid     = "LambdaEC2IsolationAssumeRole"
     effect  = "Allow"
@@ -27,6 +26,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation_assume_role" {
   }
 }
 
+## EC2 ISOLATION LAMBDA
 ### EC2 ISOLATION LAMBDA EXECUTION ROLE
 resource "aws_iam_role" "lambda_ec2_isolation" {
   name               = "${var.name_prefix}-lambda-ec2-isolation-role"

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
 
 resource "aws_iam_policy" "lambda_ec2_isolation" {
   name   = "${var.name_prefix}-lambda-ec2-isolation"
-  policy = data.aws_iam_policy_document.lambda_ec2_isolation
+  policy = data.aws_iam_policy_document.lambda_ec2_isolation.json
 }
 
 ### ATTACH EC2 ISOLATION POLICY TO EC2 ISOLATION EXECUTION ROLE

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy" "lambda_xray" {
 # LAMBDA TRUST POLICY
 data "aws_iam_policy_document" "lambda_assume_role" {
   statement {
-    sid     = "LambdaEC2IsolationAssumeRole"
+    sid     = "AllowLambdaAssumeRole"
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -1,18 +1,23 @@
 # CLOUDTRAIL
+
+## CLOUDTRAIL TRUST POLICY
+data "aws_iam_policy_document" "cloudtrail_assume_role" {
+  statement {
+    sid = "AllowCloudTrailAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+}
+
 ## CLOUDTRAIL ROLE
 resource "aws_iam_role" "cloudtrail" {
   name = "${var.name_prefix}-cloudtrail-cloudwatch-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "cloudtrail.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 
 ##CLOUDTRAIL ROLE POLICY

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -45,12 +45,12 @@ resource "aws_iam_role_policy" "cloudtrail" {
 ## FLOWLOGS TRUST POLICY
 data "aws_iam_policy_document" "flowlogs_assume_role" {
   statement {
-    sid = "AllowFlowLogsAssumeRole"
-    effect = "Allow"
+    sid     = "AllowFlowLogsAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = "vpc-flow-logs.amazonaws.com"
     }
   }
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "flowlogs_assume_role" {
 
 ## FLOWLOGS ROLE
 resource "aws_iam_role" "flowlogs" {
-  name = "${var.name_prefix}-VpcFlowLogsRole"
+  name               = "${var.name_prefix}-VpcFlowLogsRole"
   assume_role_policy = data.aws_iam_policy_document.flowlogs_assume_role.json
 
   tags = {

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -150,37 +150,38 @@ resource "aws_iam_role" "firehose_flow_logs" {
 }
 
 ## FIREHOSE FLOW LOGS POLICY
+data "aws_iam_policy_document" "firehose_flow_logs" {
+  statement {
+    sid = "AllowFirehoseWriteToCentralizedLogsS3"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    
+    resources = [
+      var.centralized_logs_bucket_arn,
+      "${var.centralized_logs_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    sid = "AllowFirehoseUseLogsKMSKey"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    
+    resources = [var.logs_cmk_arn]
+  }
+}
+
 resource "aws_iam_role_policy" "firehose_flow_logs" {
   role = aws_iam_role.firehose_flow_logs.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      # ALLOW FIREHOSE TO USE CENTRALIZED LOGS S3 BUCKET
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:PutObject",
-          "s3:AbortMultipartUpload",
-          "s3:ListBucket",
-          "s3:GetBucketLocation"
-        ]
-        Resource = [
-          var.centralized_logs_bucket_arn,
-          "${var.centralized_logs_bucket_arn}/*"
-        ]
-      },
-      # ALLOW FIREHOSE TO USE LOGS KMS KEY
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:GenerateDataKey*",
-          "kms:DescribeKey"
-        ]
-        Resource = var.logs_cmk_arn
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.firehose_flow_logs.json
 }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -41,20 +41,25 @@ resource "aws_iam_role_policy" "cloudtrail" {
 }
 
 # VPC FLOWLOGS
+
+## FLOWLOGS TRUST POLICY
+data "aws_iam_policy_document" "flowlogs_assume_role" {
+  statement {
+    sid = "AllowFlowLogsAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = "vpc-flow-logs.amazonaws.com"
+    }
+  }
+}
+
 ## FLOWLOGS ROLE
 resource "aws_iam_role" "flowlogs" {
   name = "${var.name_prefix}-VpcFlowLogsRole"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "vpc-flow-logs.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.flowlogs_assume_role.json
 
   tags = {
     Role = "VPCFlowLogs"

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -21,20 +21,23 @@ resource "aws_iam_role" "cloudtrail" {
 }
 
 ## CLOUDTRAIL ROLE POLICY
+data "aws_iam_policy_document" "cloudtrail" {
+  statement {
+    sid = "AllowCloudTrailWriteToCloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = ["${var.cloudtrail_log_group_arn}:*"]
+  }
+}
+
+## CLOUDTRAIL ROLE POLICY
 resource "aws_iam_role_policy" "cloudtrail" {
   role = aws_iam_role.cloudtrail.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ]
-      Resource = "${var.cloudtrail_log_group_arn}:*"
-    }]
-  })
+  policy = data.aws_iam_policy_document.cloudtrail.json
 }
 
 # VPC FLOWLOGS

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -66,24 +66,26 @@ resource "aws_iam_role" "flowlogs" {
 }
 
 ### FLOWLOGS ROLE POLICY
+data "aws_iam_policy_document" "flowlogs" {
+  statement {
+    sid = "AllowFlowLogsWriteToCloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+
+    resources = ["${var.flowlogs_log_group_arn}:*"]
+  }
+}
+
 resource "aws_iam_role_policy" "flowlogs" {
   name = "${var.name_prefix}-VpcFlowLogsPolicy"
   role = aws_iam_role.flowlogs.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ]
-      Resource = "${var.flowlogs_log_group_arn}:*"
-    }]
-  })
+  policy = data.aws_iam_policy_document.flowlogs
 }
 
 ## CLOUDWATCH TO FIREHOSE ROLE

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -130,7 +130,7 @@ resource "aws_iam_role_policy" "cw_to_firehose" {
 
 # KINESIS FIREHOSE
 ## KINESIS FIREHOSE TRUST POLICY
-data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
+data "aws_iam_policy_document" "firehose_flowlogs_assume_role" {
   statement {
     sid     = "AllowFirehoseAssumeRole"
     effect  = "Allow"
@@ -144,13 +144,13 @@ data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
 }
 
 ## FIREHOSE FLOW LOGS ROLE
-resource "aws_iam_role" "firehose_flow_logs" {
+resource "aws_iam_role" "firehose_flowlogs" {
   name               = "${var.name_prefix}-FirehoseFlowLogsRole"
-  assume_role_policy = data.aws_iam_policy_document.firehose_flow_logs_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.firehose_flowlogs_assume_role.json
 }
 
 ## FIREHOSE FLOW LOGS POLICY
-data "aws_iam_policy_document" "firehose_flow_logs" {
+data "aws_iam_policy_document" "firehose_flowlogs" {
   statement {
     sid    = "AllowFirehoseWriteToCentralizedLogsS3"
     effect = "Allow"
@@ -181,7 +181,7 @@ data "aws_iam_policy_document" "firehose_flow_logs" {
   }
 }
 
-resource "aws_iam_role_policy" "firehose_flow_logs" {
-  role   = aws_iam_role.firehose_flow_logs.id
-  policy = data.aws_iam_policy_document.firehose_flow_logs.json
+resource "aws_iam_role_policy" "firehose_flowlogs" {
+  role   = aws_iam_role.firehose_flowlogs.id
+  policy = data.aws_iam_policy_document.firehose_flowlogs.json
 }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "flowlogs_assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = "vpc-flow-logs.amazonaws.com"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
     }
   }
 }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -65,7 +65,7 @@ resource "aws_iam_role" "flowlogs" {
   }
 }
 
-### POLICY FOR FLOWLOGS ROLE
+### FLOWLOGS ROLE POLICY
 resource "aws_iam_role_policy" "flowlogs" {
   name = "${var.name_prefix}-VpcFlowLogsPolicy"
   role = aws_iam_role.flowlogs.id

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -88,20 +88,25 @@ resource "aws_iam_role_policy" "flowlogs" {
   policy = data.aws_iam_policy_document.flowlogs.json
 }
 
+# CLOUDWATCH TO FIREHOSE
+## CLOUDWATCH TO FIREHOSE TRUST POLICY
+data "aws_iam_policy_document" "cw_to_firehose_assume_role" {
+  statement {
+    sid = "AllowCloudWatchLogsAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["logs.amazonaws.com"]
+    }
+  }
+}
+
 ## CLOUDWATCH TO FIREHOSE ROLE
 resource "aws_iam_role" "cw_to_firehose" {
   name = "${var.name_prefix}-CloudWatchLogsToFirehose"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "logs.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.cw_to_firehose_assume_role.json
 }
 
 ### POLICY FOR CLOUDWATCH TO FIREHOSE ROLE

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -130,7 +130,7 @@ resource "aws_iam_role_policy" "cw_to_firehose" {
 
 # KINESIS FIREHOSE
 ## KINESIS FIREHOSE TRUST POLICY
-data "aws_iam_policy_document" "firehose_flowlogs_assume_role" {
+data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
   statement {
     sid     = "AllowFirehoseAssumeRole"
     effect  = "Allow"
@@ -144,13 +144,13 @@ data "aws_iam_policy_document" "firehose_flowlogs_assume_role" {
 }
 
 ## FIREHOSE FLOW LOGS ROLE
-resource "aws_iam_role" "firehose_flowlogs" {
+resource "aws_iam_role" "firehose_flow_logs" {
   name               = "${var.name_prefix}-FirehoseFlowLogsRole"
-  assume_role_policy = data.aws_iam_policy_document.firehose_flowlogs_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.firehose_flow_logs_assume_role.json
 }
 
 ## FIREHOSE FLOW LOGS POLICY
-data "aws_iam_policy_document" "firehose_flowlogs" {
+data "aws_iam_policy_document" "firehose_flow_logs" {
   statement {
     sid    = "AllowFirehoseWriteToCentralizedLogsS3"
     effect = "Allow"
@@ -181,7 +181,7 @@ data "aws_iam_policy_document" "firehose_flowlogs" {
   }
 }
 
-resource "aws_iam_role_policy" "firehose_flowlogs" {
-  role   = aws_iam_role.firehose_flowlogs.id
-  policy = data.aws_iam_policy_document.firehose_flowlogs.json
+resource "aws_iam_role_policy" "firehose_flow_logs" {
+  role   = aws_iam_role.firehose_flow_logs.id
+  policy = data.aws_iam_policy_document.firehose_flow_logs.json
 }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "cloudtrail" {
 ## FLOWLOGS TRUST POLICY
 data "aws_iam_policy_document" "flowlogs_assume_role" {
   statement {
-    sid     = "AllowFlowLogsAssumeRole"
+    sid     = "AllowVPCFlowLogsAssumeRole"
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "flowlogs" {
 ### FLOWLOGS ROLE POLICY
 data "aws_iam_policy_document" "flowlogs" {
   statement {
-    sid = "AllowFlowLogsWriteToCloudWatchLogs"
+    sid    = "AllowFlowLogsWriteToCloudWatchLogs"
     effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
@@ -83,8 +83,8 @@ data "aws_iam_policy_document" "flowlogs" {
 }
 
 resource "aws_iam_role_policy" "flowlogs" {
-  name = "${var.name_prefix}-VpcFlowLogsPolicy"
-  role = aws_iam_role.flowlogs.id
+  name   = "${var.name_prefix}-VpcFlowLogsPolicy"
+  role   = aws_iam_role.flowlogs.id
   policy = data.aws_iam_policy_document.flowlogs
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "flowlogs" {
 resource "aws_iam_role_policy" "flowlogs" {
   name   = "${var.name_prefix}-VpcFlowLogsPolicy"
   role   = aws_iam_role.flowlogs.id
-  policy = data.aws_iam_policy_document.flowlogs
+  policy = data.aws_iam_policy_document.flowlogs.json
 }
 
 ## CLOUDWATCH TO FIREHOSE ROLE

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -112,7 +112,7 @@ resource "aws_iam_role" "cw_to_firehose" {
 ## POLICY FOR CLOUDWATCH TO FIREHOSE ROLE
 data "aws_iam_policy_document" "cw_to_firehose" {
   statement {
-    sid = "AllowCloudWatchLogsWriteToFirehose"
+    sid    = "AllowCloudWatchLogsWriteToFirehose"
     effect = "Allow"
     actions = [
       "firehose:PutRecord",
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "cw_to_firehose" {
 }
 
 resource "aws_iam_role_policy" "cw_to_firehose" {
-  role = aws_iam_role.cw_to_firehose.id
+  role   = aws_iam_role.cw_to_firehose.id
   policy = data.iam_policy_document.cw_to_firehose.json
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -110,20 +110,22 @@ resource "aws_iam_role" "cw_to_firehose" {
 }
 
 ### POLICY FOR CLOUDWATCH TO FIREHOSE ROLE
+data "aws_iam_policy_document" "cw_to_firehose" {
+  statement {
+    sid = "AllowCloudWatchLogsWriteToFirehose"
+    effect = "Allow"
+    actions = [
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch"
+    ]
+
+    resources = [var.flowlogs_firehose_delivery_stream_arn]
+  }
+}
+
 resource "aws_iam_role_policy" "cw_to_firehose" {
   role = aws_iam_role.cw_to_firehose.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Action = [
-        "firehose:PutRecord",
-        "firehose:PutRecordBatch"
-      ]
-      Resource = var.flowlogs_firehose_delivery_stream_arn
-    }]
-  })
+  policy = data.iam_policy_document.cw_to_firehose.json
 }
 
 # KINESIS FIREHOSE

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -23,7 +23,7 @@ resource "aws_iam_role" "cloudtrail" {
 ## CLOUDTRAIL ROLE POLICY
 data "aws_iam_policy_document" "cloudtrail" {
   statement {
-    sid = "AllowCloudTrailWriteToCloudWatchLogs"
+    sid    = "AllowCloudTrailWriteToCloudWatchLogs"
     effect = "Allow"
     actions = [
       "logs:CreateLogStream",
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "cloudtrail" {
 
 ## CLOUDTRAIL ROLE POLICY
 resource "aws_iam_role_policy" "cloudtrail" {
-  role = aws_iam_role.cloudtrail.id
+  role   = aws_iam_role.cloudtrail.id
   policy = data.aws_iam_policy_document.cloudtrail.json
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "cw_to_firehose" {
 
 resource "aws_iam_role_policy" "cw_to_firehose" {
   role   = aws_iam_role.cw_to_firehose.id
-  policy = data.iam_policy_document.cw_to_firehose.json
+  policy = data.aws_iam_policy_document.cw_to_firehose.json
 }
 
 # KINESIS FIREHOSE

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -34,7 +34,6 @@ data "aws_iam_policy_document" "cloudtrail" {
   }
 }
 
-## CLOUDTRAIL ROLE POLICY
 resource "aws_iam_role_policy" "cloudtrail" {
   role   = aws_iam_role.cloudtrail.id
   policy = data.aws_iam_policy_document.cloudtrail.json

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role" "cloudtrail" {
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 
-##CLOUDTRAIL ROLE POLICY
+## CLOUDTRAIL ROLE POLICY
 resource "aws_iam_role_policy" "cloudtrail" {
   role = aws_iam_role.cloudtrail.id
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -132,12 +132,12 @@ resource "aws_iam_role_policy" "cw_to_firehose" {
 ## KINESIS FIREHOSE TRUST POLICY
 data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
   statement {
-    sid = "AllowFirehoseAssumeRole"
-    effect = "Allow"
+    sid     = "AllowFirehoseAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["firehose.amazonaws.com"]
     }
   }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -3,12 +3,12 @@
 ## CLOUDTRAIL TRUST POLICY
 data "aws_iam_policy_document" "cloudtrail_assume_role" {
   statement {
-    sid = "AllowCloudTrailAssumeRole"
-    effect = "Allow"
+    sid     = "AllowCloudTrailAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
   }
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
 
 ## CLOUDTRAIL ROLE
 resource "aws_iam_role" "cloudtrail" {
-  name = "${var.name_prefix}-cloudtrail-cloudwatch-role"
+  name               = "${var.name_prefix}-cloudtrail-cloudwatch-role"
   assume_role_policy = data.aws_iam_policy_document.cloudtrail_assume_role.json
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -100,6 +100,12 @@ data "aws_iam_policy_document" "cw_to_firehose_assume_role" {
       type        = "Service"
       identifiers = ["logs.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${var.primary_region}:${var.account_id}:*"]
+    }
   }
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -65,7 +65,7 @@ resource "aws_iam_role" "flowlogs" {
   }
 }
 
-### FLOWLOGS ROLE POLICY
+## FLOWLOGS ROLE POLICY
 data "aws_iam_policy_document" "flowlogs" {
   statement {
     sid    = "AllowFlowLogsWriteToCloudWatchLogs"

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -129,20 +129,25 @@ resource "aws_iam_role_policy" "cw_to_firehose" {
 }
 
 # KINESIS FIREHOSE
+## KINESIS FIREHOSE TRUST POLICY
+data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
+  statement {
+    sid = "AllowFirehoseAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
 ## FIREHOSE FLOW LOGS ROLE
 resource "aws_iam_role" "firehose_flow_logs" {
   name = "${var.name_prefix}-FirehoseFlowLogsRole"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect = "Allow"
-      Principal = {
-        Service = "firehose.amazonaws.com"
-      }
-      Action = "sts:AssumeRole"
-    }]
-  })
+  assume_role_policy = data.aws_iam_policy_document.firehose_flow_logs_assume_role.json
 }
 
 ## FIREHOSE FLOW LOGS POLICY

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -109,7 +109,7 @@ resource "aws_iam_role" "cw_to_firehose" {
   assume_role_policy = data.aws_iam_policy_document.cw_to_firehose_assume_role.json
 }
 
-### POLICY FOR CLOUDWATCH TO FIREHOSE ROLE
+## POLICY FOR CLOUDWATCH TO FIREHOSE ROLE
 data "aws_iam_policy_document" "cw_to_firehose" {
   statement {
     sid = "AllowCloudWatchLogsWriteToFirehose"

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -145,14 +145,14 @@ data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
 
 ## FIREHOSE FLOW LOGS ROLE
 resource "aws_iam_role" "firehose_flow_logs" {
-  name = "${var.name_prefix}-FirehoseFlowLogsRole"
+  name               = "${var.name_prefix}-FirehoseFlowLogsRole"
   assume_role_policy = data.aws_iam_policy_document.firehose_flow_logs_assume_role.json
 }
 
 ## FIREHOSE FLOW LOGS POLICY
 data "aws_iam_policy_document" "firehose_flow_logs" {
   statement {
-    sid = "AllowFirehoseWriteToCentralizedLogsS3"
+    sid    = "AllowFirehoseWriteToCentralizedLogsS3"
     effect = "Allow"
     actions = [
       "s3:PutObject",
@@ -160,7 +160,7 @@ data "aws_iam_policy_document" "firehose_flow_logs" {
       "s3:ListBucket",
       "s3:GetBucketLocation"
     ]
-    
+
     resources = [
       var.centralized_logs_bucket_arn,
       "${var.centralized_logs_bucket_arn}/*"
@@ -168,7 +168,7 @@ data "aws_iam_policy_document" "firehose_flow_logs" {
   }
 
   statement {
-    sid = "AllowFirehoseUseLogsKMSKey"
+    sid    = "AllowFirehoseUseLogsKMSKey"
     effect = "Allow"
     actions = [
       "kms:Encrypt",
@@ -176,12 +176,12 @@ data "aws_iam_policy_document" "firehose_flow_logs" {
       "kms:GenerateDataKey*",
       "kms:DescribeKey"
     ]
-    
+
     resources = [var.logs_cmk_arn]
   }
 }
 
 resource "aws_iam_role_policy" "firehose_flow_logs" {
-  role = aws_iam_role.firehose_flow_logs.id
+  role   = aws_iam_role.firehose_flow_logs.id
   policy = data.aws_iam_policy_document.firehose_flow_logs.json
 }

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -92,12 +92,12 @@ resource "aws_iam_role_policy" "flowlogs" {
 ## CLOUDWATCH TO FIREHOSE TRUST POLICY
 data "aws_iam_policy_document" "cw_to_firehose_assume_role" {
   statement {
-    sid = "AllowCloudWatchLogsAssumeRole"
-    effect = "Allow"
+    sid     = "AllowCloudWatchLogsAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["logs.amazonaws.com"]
     }
   }
@@ -105,7 +105,7 @@ data "aws_iam_policy_document" "cw_to_firehose_assume_role" {
 
 ## CLOUDWATCH TO FIREHOSE ROLE
 resource "aws_iam_role" "cw_to_firehose" {
-  name = "${var.name_prefix}-CloudWatchLogsToFirehose"
+  name               = "${var.name_prefix}-CloudWatchLogsToFirehose"
   assume_role_policy = data.aws_iam_policy_document.cw_to_firehose_assume_role.json
 }
 

--- a/modules/iam/logging.tf
+++ b/modules/iam/logging.tf
@@ -146,7 +146,6 @@ data "aws_iam_policy_document" "firehose_flow_logs_assume_role" {
 ## FIREHOSE FLOW LOGS ROLE
 resource "aws_iam_role" "firehose_flow_logs" {
   name = "${var.name_prefix}-FirehoseFlowLogsRole"
-
   assume_role_policy = data.aws_iam_policy_document.firehose_flow_logs_assume_role.json
 }
 

--- a/modules/iam/patch_management.tf
+++ b/modules/iam/patch_management.tf
@@ -2,21 +2,23 @@
 # IAM Role for Maintenance Window task 
 ########################################
 
+data "aws_iam_policy_document" "patch_maintenance_window" {
+  statement {
+    sid = "AllowSSMAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    
+    principals {
+      type = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "patch_maintenance_window" {
   name = "${var.name_prefix}-patch-mw-role"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "ssm.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
+  assume_role_policy = data.aws_iam_policy_document.patch_maintenance_window.json
 
   tags = {
     Name      = "${var.name_prefix}-PatchMaintenanceWindowRole"

--- a/modules/iam/patch_management.tf
+++ b/modules/iam/patch_management.tf
@@ -23,6 +23,7 @@ resource "aws_iam_role" "patch_maintenance_window" {
   tags = {
     Name      = "${var.name_prefix}-PatchMaintenanceWindowRole"
     Terraform = "true"
+    Environment = var.environment
   }
 }
 

--- a/modules/iam/patch_management.tf
+++ b/modules/iam/patch_management.tf
@@ -2,7 +2,7 @@
 # IAM Role for Maintenance Window task 
 ########################################
 
-data "aws_iam_policy_document" "patch_maintenance_window" {
+data "aws_iam_policy_document" "patch_maintenance_window_assume_role" {
   statement {
     sid     = "AllowSSMAssumeRole"
     effect  = "Allow"
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "patch_maintenance_window" {
 resource "aws_iam_role" "patch_maintenance_window" {
   name = "${var.name_prefix}-patch-mw-role"
 
-  assume_role_policy = data.aws_iam_policy_document.patch_maintenance_window.json
+  assume_role_policy = data.aws_iam_policy_document.patch_maintenance_window_assume_role.json
 
   tags = {
     Name        = "${var.name_prefix}-PatchMaintenanceWindowRole"

--- a/modules/iam/patch_management.tf
+++ b/modules/iam/patch_management.tf
@@ -4,12 +4,12 @@
 
 data "aws_iam_policy_document" "patch_maintenance_window" {
   statement {
-    sid = "AllowSSMAssumeRole"
-    effect = "Allow"
+    sid     = "AllowSSMAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    
+
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["ssm.amazonaws.com"]
     }
   }

--- a/modules/iam/patch_management.tf
+++ b/modules/iam/patch_management.tf
@@ -21,8 +21,8 @@ resource "aws_iam_role" "patch_maintenance_window" {
   assume_role_policy = data.aws_iam_policy_document.patch_maintenance_window.json
 
   tags = {
-    Name      = "${var.name_prefix}-PatchMaintenanceWindowRole"
-    Terraform = "true"
+    Name        = "${var.name_prefix}-PatchMaintenanceWindowRole"
+    Terraform   = "true"
     Environment = var.environment
   }
 }

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -20,19 +20,19 @@ resource "aws_accessanalyzer_analyzer" "main" {
 ## EVENTBRIDGE ROLE TRUST POLICY
 data "aws_iam_policy_document" "eventbridge_putevents_to_secops_assume_role" {
   statement {
-    sid = "AllowEventBridgeAssumeRole"
-    effect = "Allow"
+    sid     = "AllowEventBridgeAssumeRole"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["events.amazonaws.com"]
     }
   }
 }
 
 resource "aws_iam_role" "eventbridge_putevents_to_secops" {
-  name = "${var.name_prefix}-EventBridgePutEventsToSecopsBus"
+  name               = "${var.name_prefix}-EventBridgePutEventsToSecopsBus"
   assume_role_policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops_assume_role.json
 }
 

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -17,20 +17,26 @@ resource "aws_accessanalyzer_analyzer" "main" {
 }
 
 # EVENTBRIDGE ROLE
-resource "aws_iam_role" "eventbridge_putevents_to_secops" {
-  name = "${var.name_prefix}-EventBridgePutEventsToSecopsBus"
+## EVENTBRIDGE ROLE TRUST POLICY
+data "aws_iam_policy_document" "eventbridge_putevents_to_secops_assume_role" {
+  statement {
+    sid = "AllowEventBridgeAssumeRole"
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = { Service = "events.amazonaws.com" }
-      Action    = "sts:AssumeRole"
-    }]
-  })
+    principals {
+      type = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
 }
 
-# ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
+resource "aws_iam_role" "eventbridge_putevents_to_secops" {
+  name = "${var.name_prefix}-EventBridgePutEventsToSecopsBus"
+  assume_role_policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops_assume_role.json
+}
+
+## ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
 resource "aws_iam_role_policy" "eventbridge_putevents_to_secops" {
   role = aws_iam_role.eventbridge_putevents_to_secops.id
   policy = jsonencode({

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -39,8 +39,8 @@ resource "aws_iam_role" "eventbridge_putevents_to_secops" {
 # ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
 data "aws_iam_policy_document" "eventbridge_putevents_to_secops" {
   statement {
-    sid = "AllowEventBridgePutEventsToSecopsBus"
-    effect = "Allow"
+    sid     = "AllowEventBridgePutEventsToSecopsBus"
+    effect  = "Allow"
     actions = ["events:PutEvents"]
 
     resources = [var.secops_event_bus_arn]
@@ -48,6 +48,6 @@ data "aws_iam_policy_document" "eventbridge_putevents_to_secops" {
 }
 
 resource "aws_iam_role_policy" "eventbridge_putevents_to_secops" {
-  role = aws_iam_role.eventbridge_putevents_to_secops.id
+  role   = aws_iam_role.eventbridge_putevents_to_secops.id
   policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops.json
 }

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -37,14 +37,17 @@ resource "aws_iam_role" "eventbridge_putevents_to_secops" {
 }
 
 # ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
+data "aws_iam_policy_document" "eventbridge_putevents_to_secops" {
+  statement {
+    sid = "AllowEventBridgePutEventsToSecopsBus"
+    effect = "Allow"
+    actions = ["events:PutEvents"]
+
+    resources = [var.secops_event_bus_arn]
+  }
+}
+
 resource "aws_iam_role_policy" "eventbridge_putevents_to_secops" {
   role = aws_iam_role.eventbridge_putevents_to_secops.id
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect   = "Allow"
-      Action   = "events:PutEvents"
-      Resource = var.secops_event_bus_arn
-    }]
-  })
+  policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops.json
 }

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -16,8 +16,7 @@ resource "aws_accessanalyzer_analyzer" "main" {
   }
 }
 
-# EVENTBRIDGE ROLE
-## EVENTBRIDGE ROLE TRUST POLICY
+## EVENTBRIDGE TRUST POLICY
 data "aws_iam_policy_document" "eventbridge_putevents_to_secops_assume_role" {
   statement {
     sid     = "AllowEventBridgeAssumeRole"

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -36,7 +36,7 @@ resource "aws_iam_role" "eventbridge_putevents_to_secops" {
   assume_role_policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops_assume_role.json
 }
 
-## ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
+# ALLOW EVENTBRIDGE TO PUT EVENTS TO SECOPS BUS
 resource "aws_iam_role_policy" "eventbridge_putevents_to_secops" {
   role = aws_iam_role.eventbridge_putevents_to_secops.id
   policy = jsonencode({

--- a/modules/iam/security_integrations.tf
+++ b/modules/iam/security_integrations.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "eventbridge_putevents_to_secops_assume_role" {
   }
 }
 
+# EVENTBRIDGE ROLE
 resource "aws_iam_role" "eventbridge_putevents_to_secops" {
   name               = "${var.name_prefix}-EventBridgePutEventsToSecopsBus"
   assume_role_policy = data.aws_iam_policy_document.eventbridge_putevents_to_secops_assume_role.json

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -3,7 +3,7 @@
 # GENERIC POLICY TO ALLOW READ ACCESS TO CENTRALIZED LOGS S3 BUCKET
 data "aws_iam_policy_document" "logs_s3_readonly" {
   statement {
-    sid = "ListCentralizedLogsBucket"
+    sid    = "ListCentralizedLogsBucket"
     effect = "Allow"
     actions = [
       "s3:ListBucket",
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "logs_s3_readonly" {
   }
 
   statement {
-    sid = "ReadCentralizedLogsObjects"
+    sid    = "ReadCentralizedLogsObjects"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "logs_s3_readonly" {
 resource "aws_iam_policy" "logs_s3_readonly" {
   name        = "${var.name_prefix}-CentralizedLogsS3ReadOnly"
   description = "Read-only access to Centralized Logs S3 bucket (no delete, no write)"
-  policy = data.aws_iam_policy_document.logs_s3_readonly
+  policy      = data.aws_iam_policy_document.logs_s3_readonly
 }
 
 ## GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -33,7 +33,7 @@ resource "aws_iam_policy" "logs_s3_readonly" {
   policy      = data.aws_iam_policy_document.logs_s3_readonly
 }
 
-## GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK
+# GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK
 resource "aws_iam_policy" "logs_cmk_decrypt" {
   name        = "${var.name_prefix}-LogsKmsDecrypt"
   description = "Allow decryption of objects encrypted with the Logs CMK"

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -1,36 +1,36 @@
 # SHARED POLICIES ATTACHED TO MULTIPLE ROLES
-## GENERIC POLICY TO ALLOW READ ACCESS TO CENTRALIZED LOGS S3 BUCKET
+
+# GENERIC POLICY TO ALLOW READ ACCESS TO CENTRALIZED LOGS S3 BUCKET
+data "aws_iam_policy_document" "logs_s3_readonly" {
+  statement {
+    sid = "ListCentralizedLogsBucket"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+
+    resources = [var.centralized_logs_bucket_arn]
+  }
+
+  statement {
+    sid = "ReadCentralizedLogsObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging"
+    ]
+
+    resources = ["${var.centralized_logs_bucket_arn}/*"]
+  }
+}
+
 resource "aws_iam_policy" "logs_s3_readonly" {
   name        = "${var.name_prefix}-CentralizedLogsS3ReadOnly"
   description = "Read-only access to Centralized Logs S3 bucket (no delete, no write)"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      # LIST BUCKET + READ BUCKET METADATA
-      {
-        Sid    = "ListCentralizedLogsBucket"
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation"
-        ]
-        Resource = var.centralized_logs_bucket_arn
-      },
-      # READ OBJECTS + VERSIONS
-      {
-        Sid    = "ReadCentralizedLogsObjects"
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:GetObjectVersion",
-          "s3:GetObjectTagging",
-          "s3:GetObjectVersionTagging"
-        ]
-        Resource = "${var.centralized_logs_bucket_arn}/*"
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.logs_s3_readonly
 }
 
 ## GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -34,22 +34,21 @@ resource "aws_iam_policy" "logs_s3_readonly" {
 }
 
 # GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK
+data "aws_iam_policy_document" "logs_cmk_decrypt" {
+  statement {
+    sid = "AllowDecryptLogsKey"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [var.logs_cmk_arn]
+  }
+}
+
 resource "aws_iam_policy" "logs_cmk_decrypt" {
   name        = "${var.name_prefix}-LogsKmsDecrypt"
   description = "Allow decryption of objects encrypted with the Logs CMK"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowDecryptLogsKey"
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:DescribeKey"
-        ]
-        Resource = var.logs_cmk_arn
-      }
-    ]
-  })
+  policy = data.aws_iam_policy_document.logs_cmk_decrypt.json
 }

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "logs_s3_readonly" {
 resource "aws_iam_policy" "logs_s3_readonly" {
   name        = "${var.name_prefix}-CentralizedLogsS3ReadOnly"
   description = "Read-only access to Centralized Logs S3 bucket (no delete, no write)"
-  policy      = data.aws_iam_policy_document.logs_s3_readonly
+  policy      = data.aws_iam_policy_document.logs_s3_readonly.json
 }
 
 # GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK

--- a/modules/iam/shared_policies.tf
+++ b/modules/iam/shared_policies.tf
@@ -36,7 +36,7 @@ resource "aws_iam_policy" "logs_s3_readonly" {
 # GENERIC POLICY TO ALLOW DECRYPTION OF OBJECTS ENCRYPTED WITH THE LOGS CMK
 data "aws_iam_policy_document" "logs_cmk_decrypt" {
   statement {
-    sid = "AllowDecryptLogsKey"
+    sid    = "AllowDecryptLogsKey"
     effect = "Allow"
     actions = [
       "kms:Decrypt",
@@ -50,5 +50,5 @@ data "aws_iam_policy_document" "logs_cmk_decrypt" {
 resource "aws_iam_policy" "logs_cmk_decrypt" {
   name        = "${var.name_prefix}-LogsKmsDecrypt"
   description = "Allow decryption of objects encrypted with the Logs CMK"
-  policy = data.aws_iam_policy_document.logs_cmk_decrypt.json
+  policy      = data.aws_iam_policy_document.logs_cmk_decrypt.json
 }


### PR DESCRIPTION
Closes #383
Closes #384 