### PR TITLE
refactor: Make 'backup_schedule' and 'delete_backups_after_days' vars nullable + remove them from each env

### DIFF
--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -228,14 +228,12 @@ variable "backup_schedule" {
   description = "CRON expression for when backups are performed"
   type        = string
   default     = "cron(0 5 * * ? *)"
-  nullable    = false
 }
 
 variable "delete_backups_after_days" {
   description = "Number of days to retain backups before deletion"
   type        = string
   default     = "30"
-  nullable    = false
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -14,8 +14,6 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  backup_schedule                    = var.backup_schedule
-  delete_backups_after_days          = var.delete_backups_after_days
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -100,18 +100,6 @@ variable "backup_enabled" {
   default     = null
 }
 
-variable "backup_schedule" {
-  description = "CRON expression for when backups are performed"
-  type        = string
-  default     = null
-}
-
-variable "delete_backups_after_days" {
-  description = "Number of days to retain backups before deletion"
-  type        = string
-  default     = null
-}
-
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -14,8 +14,6 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  backup_schedule                    = var.backup_schedule
-  delete_backups_after_days          = var.delete_backups_after_days
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -100,18 +100,6 @@ variable "backup_enabled" {
   default     = null
 }
 
-variable "backup_schedule" {
-  description = "CRON expression for when backups are performed"
-  type        = string
-  default     = null
-}
-
-variable "delete_backups_after_days" {
-  description = "Number of days to retain backups before deletion"
-  type        = string
-  default     = null
-}
-
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -14,8 +14,6 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  backup_schedule                    = var.backup_schedule
-  delete_backups_after_days          = var.delete_backups_after_days
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -100,18 +100,6 @@ variable "backup_enabled" {
   default     = null
 }
 
-variable "backup_schedule" {
-  description = "CRON expression for when backups are performed"
-  type        = string
-  default     = null
-}
-
-variable "delete_backups_after_days" {
-  description = "Number of days to retain backups before deletion"
-  type        = string
-  default     = null
-}
-
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)


### PR DESCRIPTION
Closes #441 - Make var.backup_schedule and var.delete_backups_after_days nullable in 'baseline' and remove them from being passed from each env