### PR TITLE
refactor: every val script to use `get_aws_account_id` and `get_aws_caller_arn` helper funcs if not already using

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,6 @@ Potential future improvements include:
 - Improve dashboarding and visual evidence outputs
 - Add configurable VPC endpoint service lists
 - Add additional deployment profile-controlled services
-- Continue refactoring remaining IAM policy JSON outside modules/iam
 - Add SCP strategy and Terraform implementation
 - Add cross-account GuardDuty aggregation
 - Add cross-account Security Hub aggregation

--- a/scripts/validation/validate-backup.sh
+++ b/scripts/validation/validate-backup.sh
@@ -133,19 +133,8 @@ fi
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-compute.sh
+++ b/scripts/validation/validate-compute.sh
@@ -102,19 +102,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-eventbridge.sh
+++ b/scripts/validation/validate-eventbridge.sh
@@ -96,19 +96,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-  "${aws_args[@]}" \
-  --query Account \
-  --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-  "${aws_args[@]}" \
-  --query Arn \
-  --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "${AWS_PROFILE:-}" "${AWS_REGION:-}")"
+CALLER_ARN="$(get_aws_caller_arn "${AWS_PROFILE:-}" "${AWS_REGION:-}")"
 
 if [[ -z "${ACCOUNT_ID}" || "${ACCOUNT_ID}" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-iam.sh
+++ b/scripts/validation/validate-iam.sh
@@ -93,19 +93,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID."

--- a/scripts/validation/validate-kms.sh
+++ b/scripts/validation/validate-kms.sh
@@ -105,19 +105,8 @@ fi
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-lambda.sh
+++ b/scripts/validation/validate-lambda.sh
@@ -96,19 +96,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-logging.sh
+++ b/scripts/validation/validate-logging.sh
@@ -104,19 +104,8 @@ fi
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-networking.sh
+++ b/scripts/validation/validate-networking.sh
@@ -88,6 +88,36 @@ require_value_in_list "$EFFECTIVE_EGRESS_MODE" "network_firewall nat_only vpc_en
 
 success "effective_egress_mode is valid: $EFFECTIVE_EGRESS_MODE"
 
+section "Checking AWS caller identity"
+
+info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
+info "AWS_REGION: ${AWS_REGION}"
+
+AWS_ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+AWS_CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
+
+if [[ -z "$AWS_ACCOUNT_ID" || "$AWS_ACCOUNT_ID" == "None" ]]; then
+  fail "Unable to resolve AWS account ID"
+fi
+
+if [[ -z "$AWS_CALLER_ARN" || "$AWS_CALLER_ARN" == "None" ]]; then
+  fail "Unable to resolve AWS caller ARN"
+fi
+
+success "AWS credentials are valid"
+info "AWS account ID: $AWS_ACCOUNT_ID"
+info "AWS caller ARN: $AWS_CALLER_ARN"
+
+if [[ -n "$EXPECTED_ACCOUNT_ID" ]]; then
+  if [[ "$AWS_ACCOUNT_ID" == "$EXPECTED_ACCOUNT_ID" ]]; then
+    success "AWS account ID matches expected account: $EXPECTED_ACCOUNT_ID"
+  else
+    fail "AWS account ID mismatch. Expected ${EXPECTED_ACCOUNT_ID}, got ${AWS_ACCOUNT_ID}"
+  fi
+else
+  warn "EXPECTED_ACCOUNT_ID not set. Skipping explicit account ID match check."
+fi
+
 section "Resolving VPC"
 
 # Prefer Terraform output if present. Fall back to AWS tag lookup.

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -116,19 +116,8 @@ success "effective_inspector_enabled is valid: $EFFECTIVE_INSPECTOR_ENABLED"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-sns.sh
+++ b/scripts/validation/validate-sns.sh
@@ -95,19 +95,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-sqs.sh
+++ b/scripts/validation/validate-sqs.sh
@@ -99,19 +99,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-ssm.sh
+++ b/scripts/validation/validate-ssm.sh
@@ -97,19 +97,8 @@ success "Terraform outputs are readable"
 
 section "Checking AWS caller identity"
 
-ACCOUNT_ID="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Account \
-    --output text
-)"
-
-CALLER_ARN="$(
-  aws sts get-caller-identity \
-    "${aws_args[@]}" \
-    --query Arn \
-    --output text
-)"
+ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
 
 if [[ -z "$ACCOUNT_ID" || "$ACCOUNT_ID" == "None" ]]; then
   fail "Unable to resolve AWS account ID"

--- a/scripts/validation/validate-vpc-endpoints.sh
+++ b/scripts/validation/validate-vpc-endpoints.sh
@@ -99,6 +99,36 @@ else
   EFFECTIVE_EGRESS_MODE="unknown"
 fi
 
+section "Checking AWS caller identity"
+
+info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
+info "AWS_REGION: ${AWS_REGION}"
+
+AWS_ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+AWS_CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
+
+if [[ -z "$AWS_ACCOUNT_ID" || "$AWS_ACCOUNT_ID" == "None" ]]; then
+  fail "Unable to resolve AWS account ID"
+fi
+
+if [[ -z "$AWS_CALLER_ARN" || "$AWS_CALLER_ARN" == "None" ]]; then
+  fail "Unable to resolve AWS caller ARN"
+fi
+
+success "AWS credentials are valid"
+info "AWS account ID: $AWS_ACCOUNT_ID"
+info "AWS caller ARN: $AWS_CALLER_ARN"
+
+if [[ -n "$EXPECTED_ACCOUNT_ID" ]]; then
+  if [[ "$AWS_ACCOUNT_ID" == "$EXPECTED_ACCOUNT_ID" ]]; then
+    success "AWS account ID matches expected account: $EXPECTED_ACCOUNT_ID"
+  else
+    fail "AWS account ID mismatch. Expected ${EXPECTED_ACCOUNT_ID}, got ${AWS_ACCOUNT_ID}"
+  fi
+else
+  warn "EXPECTED_ACCOUNT_ID not set. Skipping explicit account ID match check."
+fi
+
 section "Resolving VPC"
 
 # Prefer Terraform output if present. Fall back to AWS tag lookup.


### PR DESCRIPTION
Closes #456 - Refactor every validation script to use the get_aws_account_id and get_aws_caller_arn helper funcs if not already using