### PR TITLE
chore: Make resources that Inspector scans configurable via var; also fix bug with Inspector and make 'effective_inspector_enabled' var effective

### DIFF
--- a/baseline/locals.tf
+++ b/baseline/locals.tf
@@ -96,5 +96,9 @@ locals {
     : local.is_production_profile
   )
 
-  effective_inspector_enabled = !local.is_minimal_profile
+  effective_inspector_enabled = (
+    var.inspector_enabled != null
+    ? var.inspector_enabled
+    : !local.is_minimal_profile
+  )
 }

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -119,9 +119,9 @@ module "security" {
   primary_region               = var.primary_region
   centralized_logs_bucket_name = module.storage.centralized_logs_bucket_name
 
-  guardduty_features = var.guardduty_features
-  enable_rules       = local.effective_enable_rules
-  inspector_enabled = var.inspector_enabled
+  guardduty_features       = var.guardduty_features
+  enable_rules             = local.effective_enable_rules
+  inspector_enabled        = var.inspector_enabled
   inspector_resource_types = var.inspector_resource_types
 
   enable_config               = local.effective_enable_config

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -121,7 +121,7 @@ module "security" {
 
   guardduty_features       = var.guardduty_features
   enable_rules             = local.effective_enable_rules
-  inspector_enabled        = var.inspector_enabled
+  inspector_enabled        = local.effective_inspector_enabled
   inspector_resource_types = var.inspector_resource_types
 
   enable_config               = local.effective_enable_config

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -121,6 +121,7 @@ module "security" {
 
   guardduty_features = var.guardduty_features
   enable_rules       = local.effective_enable_rules
+  inspector_enabled = var.inspector_enabled
   inspector_resource_types = var.inspector_resource_types
 
   enable_config               = local.effective_enable_config

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -121,6 +121,7 @@ module "security" {
 
   guardduty_features = var.guardduty_features
   enable_rules       = local.effective_enable_rules
+  inspector_resource_types = var.inspector_resource_types
 
   enable_config               = local.effective_enable_config
   config_role_arn             = module.iam.config_role_arn

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -188,6 +188,12 @@ variable "backup_enabled" {
   default     = null
 }
 
+variable "inspector_enabled" {
+  description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
+  type = bool
+  default = null
+}
+
 variable "ip_enrichment_write_to_securityhub" {
   description = "Define whether you want the IP Enrichment Lambda function to write its enrichments to SecurityHub findings"
   type        = bool
@@ -240,4 +246,18 @@ variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
   default     = []
+}
+
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
 }

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -208,7 +208,7 @@ variable "inspector_resource_types" {
   }
 
   validation {
-    condition     = (
+    condition = (
       var.inspector_enabled == false
       || length(var.inspector_resource_types) > 0
     )

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -206,6 +206,22 @@ variable "inspector_resource_types" {
     ])
     error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
+
+  validation {
+    condition     = (
+      var.inspector_enabled == false
+      || length(var.inspector_resource_types) > 0
+    )
+    error_message = "inspector_resource_types must contain at least one resource type when inspector_enabled is true or profile-defaulted to enabled."
+  }
+
+  validation {
+    condition = (
+      !contains(var.inspector_resource_types, "LAMBDA_CODE")
+      || contains(var.inspector_resource_types, "LAMBDA")
+    )
+    error_message = "inspector_resource_types cannot include LAMBDA_CODE unless LAMBDA is also included."
+  }
 }
 
 variable "ip_enrichment_write_to_securityhub" {

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -194,6 +194,20 @@ variable "inspector_enabled" {
   default     = null
 }
 
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}
+
 variable "ip_enrichment_write_to_securityhub" {
   description = "Define whether you want the IP Enrichment Lambda function to write its enrichments to SecurityHub findings"
   type        = bool
@@ -246,18 +260,4 @@ variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
   default     = []
-}
-
-variable "inspector_resource_types" {
-  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
-  type        = list(string)
-  default     = ["EC2"]
-
-  validation {
-    condition = alltrue([
-      for resource_type in var.inspector_resource_types :
-      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
-    ])
-    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
-  }
 }

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -190,8 +190,8 @@ variable "backup_enabled" {
 
 variable "inspector_enabled" {
   description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
-  type = bool
-  default = null
+  type        = bool
+  default     = null
 }
 
 variable "ip_enrichment_write_to_securityhub" {

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -15,6 +15,7 @@ module "baseline" {
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
   inspector_enabled = var.inspector_enabled
+  inspector_resource_types = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -14,6 +14,7 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
+  inspector_enabled = var.inspector_enabled
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -14,8 +14,8 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  inspector_enabled = var.inspector_enabled
-  inspector_resource_types = var.inspector_resource_types
+  inspector_enabled                  = var.inspector_enabled
+  inspector_resource_types           = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -118,6 +118,22 @@ variable "inspector_resource_types" {
     ])
     error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
+
+  validation {
+    condition     = (
+      var.inspector_enabled == false
+      || length(var.inspector_resource_types) > 0
+    )
+    error_message = "inspector_resource_types must contain at least one resource type when inspector_enabled is true or profile-defaulted to enabled."
+  }
+
+  validation {
+    condition = (
+      !contains(var.inspector_resource_types, "LAMBDA_CODE")
+      || contains(var.inspector_resource_types, "LAMBDA")
+    )
+    error_message = "inspector_resource_types cannot include LAMBDA_CODE unless LAMBDA is also included."
+  }
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -120,7 +120,7 @@ variable "inspector_resource_types" {
   }
 
   validation {
-    condition     = (
+    condition = (
       var.inspector_enabled == false
       || length(var.inspector_resource_types) > 0
     )

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -106,6 +106,20 @@ variable "inspector_enabled" {
   default     = null
 }
 
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
@@ -121,19 +135,5 @@ variable "secops_emails" {
   validation {
     condition     = alltrue([for e in var.secops_emails : can(regex("^.+@.+\\..+$", e))])
     error_message = "Each entry in secops_emails must be a valid email address."
-  }
-}
-
-variable "inspector_resource_types" {
-  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
-  type        = list(string)
-  default     = ["EC2"]
-
-  validation {
-    condition = alltrue([
-      for resource_type in var.inspector_resource_types :
-      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
-    ])
-    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -123,3 +123,17 @@ variable "secops_emails" {
     error_message = "Each entry in secops_emails must be a valid email address."
   }
 }
+
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -102,8 +102,8 @@ variable "backup_enabled" {
 
 variable "inspector_enabled" {
   description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
-  type = bool
-  default = null
+  type        = bool
+  default     = null
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -100,6 +100,12 @@ variable "backup_enabled" {
   default     = null
 }
 
+variable "inspector_enabled" {
+  description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
+  type = bool
+  default = null
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -15,6 +15,7 @@ module "baseline" {
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
   inspector_enabled = var.inspector_enabled
+  inspector_resource_types = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -14,6 +14,7 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
+  inspector_enabled = var.inspector_enabled
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -14,8 +14,8 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  inspector_enabled = var.inspector_enabled
-  inspector_resource_types = var.inspector_resource_types
+  inspector_enabled                  = var.inspector_enabled
+  inspector_resource_types           = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -118,6 +118,22 @@ variable "inspector_resource_types" {
     ])
     error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
+
+  validation {
+    condition     = (
+      var.inspector_enabled == false
+      || length(var.inspector_resource_types) > 0
+    )
+    error_message = "inspector_resource_types must contain at least one resource type when inspector_enabled is true or profile-defaulted to enabled."
+  }
+
+  validation {
+    condition = (
+      !contains(var.inspector_resource_types, "LAMBDA_CODE")
+      || contains(var.inspector_resource_types, "LAMBDA")
+    )
+    error_message = "inspector_resource_types cannot include LAMBDA_CODE unless LAMBDA is also included."
+  }
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -120,7 +120,7 @@ variable "inspector_resource_types" {
   }
 
   validation {
-    condition     = (
+    condition = (
       var.inspector_enabled == false
       || length(var.inspector_resource_types) > 0
     )

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -106,6 +106,20 @@ variable "inspector_enabled" {
   default     = null
 }
 
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
@@ -121,19 +135,5 @@ variable "secops_emails" {
   validation {
     condition     = alltrue([for e in var.secops_emails : can(regex("^.+@.+\\..+$", e))])
     error_message = "Each entry in secops_emails must be a valid email address."
-  }
-}
-
-variable "inspector_resource_types" {
-  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
-  type        = list(string)
-  default     = ["EC2"]
-
-  validation {
-    condition = alltrue([
-      for resource_type in var.inspector_resource_types :
-      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
-    ])
-    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -102,8 +102,8 @@ variable "backup_enabled" {
 
 variable "inspector_enabled" {
   description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
-  type = bool
-  default = null
+  type        = bool
+  default     = null
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -100,6 +100,12 @@ variable "backup_enabled" {
   default     = null
 }
 
+variable "inspector_enabled" {
+  description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
+  type = bool
+  default = null
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
@@ -115,5 +121,19 @@ variable "secops_emails" {
   validation {
     condition     = alltrue([for e in var.secops_emails : can(regex("^.+@.+\\..+$", e))])
     error_message = "Each entry in secops_emails must be a valid email address."
+  }
+}
+
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
 }

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -15,6 +15,7 @@ module "baseline" {
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
   inspector_enabled = var.inspector_enabled
+  inspector_resource_types = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -14,6 +14,7 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
+  inspector_enabled = var.inspector_enabled
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -14,8 +14,8 @@ module "baseline" {
   enable_config                      = var.enable_config
   enable_rules                       = var.enable_rules
   backup_enabled                     = var.backup_enabled
-  inspector_enabled = var.inspector_enabled
-  inspector_resource_types = var.inspector_resource_types
+  inspector_enabled                  = var.inspector_enabled
+  inspector_resource_types           = var.inspector_resource_types
   deployment_profile                 = var.deployment_profile
   egress_mode                        = var.egress_mode
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -118,6 +118,22 @@ variable "inspector_resource_types" {
     ])
     error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
+
+  validation {
+    condition     = (
+      var.inspector_enabled == false
+      || length(var.inspector_resource_types) > 0
+    )
+    error_message = "inspector_resource_types must contain at least one resource type when inspector_enabled is true or profile-defaulted to enabled."
+  }
+
+  validation {
+    condition = (
+      !contains(var.inspector_resource_types, "LAMBDA_CODE")
+      || contains(var.inspector_resource_types, "LAMBDA")
+    )
+    error_message = "inspector_resource_types cannot include LAMBDA_CODE unless LAMBDA is also included."
+  }
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -120,7 +120,7 @@ variable "inspector_resource_types" {
   }
 
   validation {
-    condition     = (
+    condition = (
       var.inspector_enabled == false
       || length(var.inspector_resource_types) > 0
     )

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -106,6 +106,20 @@ variable "inspector_enabled" {
   default     = null
 }
 
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
@@ -121,19 +135,5 @@ variable "secops_emails" {
   validation {
     condition     = alltrue([for e in var.secops_emails : can(regex("^.+@.+\\..+$", e))])
     error_message = "Each entry in secops_emails must be a valid email address."
-  }
-}
-
-variable "inspector_resource_types" {
-  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
-  type        = list(string)
-  default     = ["EC2"]
-
-  validation {
-    condition = alltrue([
-      for resource_type in var.inspector_resource_types :
-      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
-    ])
-    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -102,8 +102,8 @@ variable "backup_enabled" {
 
 variable "inspector_enabled" {
   description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
-  type = bool
-  default = null
+  type        = bool
+  default     = null
 }
 
 variable "break_glass_trusted_principal_arns" {

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -100,6 +100,12 @@ variable "backup_enabled" {
   default     = null
 }
 
+variable "inspector_enabled" {
+  description = "Whether to enable Amazon Inspector. Set to null to use the deployment_profile default."
+  type = bool
+  default = null
+}
+
 variable "break_glass_trusted_principal_arns" {
   description = "ARNs allowed to assume the break-glass admin role. Keep this list extremely small."
   type        = list(string)
@@ -115,5 +121,19 @@ variable "secops_emails" {
   validation {
     condition     = alltrue([for e in var.secops_emails : can(regex("^.+@.+\\..+$", e))])
     error_message = "Each entry in secops_emails must be a valid email address."
+  }
+}
+
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
   }
 }

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -61,7 +61,7 @@ resource "aws_securityhub_standards_subscription" "main" {
 resource "aws_inspector2_enabler" "main" {
   count = var.inspector_enabled ? 1 : 0
 
-  account_ids = [var.account_id]
+  account_ids    = [var.account_id]
   resource_types = var.inspector_resource_types
 }
 

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -62,11 +62,7 @@ resource "aws_inspector2_enabler" "main" {
   count = var.inspector_enabled ? 1 : 0
 
   account_ids = [var.account_id]
-  resource_types = [
-    "EC2",
-    "LAMBDA",
-    "LAMBDA_CODE"
-  ]
+  resource_types = var.inspector_resource_types
 }
 
 ## SUBSCRIBE SECURITY HUB TO AMAZON INSPECTOR PRODUCT

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -59,6 +59,8 @@ resource "aws_securityhub_standards_subscription" "main" {
 # INSPECTOR RESOURCES
 ## ENABLE INSPECTORv2
 resource "aws_inspector2_enabler" "main" {
+  count = var.inspector_enabled ? 1 : 0
+
   account_ids = [var.account_id]
   resource_types = [
     "EC2",
@@ -79,7 +81,6 @@ resource "aws_kms_key" "logs" {
   description             = "CMK for centralized logging (CloudTrail, Config, Flow Logs)"
   enable_key_rotation     = true
   deletion_window_in_days = 30
-
   lifecycle {
     prevent_destroy = false # CHANGE THIS IN PROD
   }

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -74,6 +74,6 @@ variable "enable_rules" {
   }
 }
 
-variable "enable_inspector" {
+variable "inspector_enabled" {
   type = bool
 }

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -73,3 +73,7 @@ variable "enable_rules" {
     kms_baseline        = true
   }
 }
+
+variable "enable_inspector" {
+  type = bool
+}

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -77,3 +77,17 @@ variable "enable_rules" {
 variable "inspector_enabled" {
   type = bool
 }
+
+variable "inspector_resource_types" {
+  description = "Amazon Inspector resource types to enable. Lambda scan types are disabled by default because this baseline encrypts Lambda resources with customer-managed KMS keys, which Inspector Lambda scanning does not support."
+  type        = list(string)
+  default     = ["EC2"]
+
+  validation {
+    condition = alltrue([
+      for resource_type in var.inspector_resource_types :
+      contains(["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"], resource_type)
+    ])
+    error_message = "inspector_resource_types must contain only EC2, ECR, LAMBDA, LAMBDA_CODE, or CODE_REPOSITORY."
+  }
+}


### PR DESCRIPTION
Closes #465 - Fix issue where local.effective_inspector_enabled is not being used
Closes #464 - Make resources that Inspector scans configurable