### PR TITLE
chore: update `scripts/validation/validate-security-services.sh` to respect new Inspector configuration (only scan what's defined in `var.inspector_resource_types`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.2.1
+
+### Fixed
+
+- Fixed Amazon Inspector enablement wiring so the security module respects the resolved `effective_inspector_enabled` value.
+- Updated Inspector validation to check the effective Inspector resource types instead of assuming EC2, Lambda, and Lambda code scanning are all enabled.
+- Removed unnecessary Amazon Inspector access from the Lambda KMS key policy.
+
+### Changed
+
+- Added configurable `inspector_resource_types` support.
+- Defaulted Amazon Inspector resource types to EC2 scanning only.
+- Disabled Lambda and Lambda code scanning by default because the baseline uses customer-managed KMS encryption for Lambda resources.
+- Updated security module documentation to reflect configurable Inspector behavior and Lambda CMK policy changes.
+
 ## v1.2.0
 
 ### Added

--- a/baseline/outputs.tf
+++ b/baseline/outputs.tf
@@ -73,6 +73,11 @@ output "effective_inspector_enabled" {
   value       = local.effective_inspector_enabled
 }
 
+output "effective_inspector_resource_types" {
+  description = "Amazon Inspector resource types enabled after profile and override resolution."
+  value       = local.effective_inspector_enabled ? var.inspector_resource_types : []
+}
+
 output "db_port" {
   description = "Port used by the database (Postgres=5432, MySQL=3306)"
   value       = var.db_port

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -75,7 +75,7 @@ output "effective_inspector_enabled" {
 
 output "effective_inspector_resource_types" {
   description = "Amazon Inspector resource types enabled after profile and override resolution."
-  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+  value       = module.baseline.effective_inspector_enabled ? var.inspector_resource_types : []
 }
 
 output "db_port" {

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -73,6 +73,11 @@ output "effective_inspector_enabled" {
   value       = module.baseline.effective_inspector_enabled
 }
 
+output "effective_inspector_resource_types" {
+  description = "Amazon Inspector resource types enabled after profile and override resolution."
+  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+}
+
 output "db_port" {
   description = "Port used by the database (Postgres=5432, MySQL=3306)"
   value       = module.baseline.db_port

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -75,7 +75,7 @@ output "effective_inspector_enabled" {
 
 output "effective_inspector_resource_types" {
   description = "Amazon Inspector resource types enabled after profile and override resolution."
-  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+  value       = module.baseline.effective_inspector_enabled ? var.inspector_resource_types : []
 }
 
 output "db_port" {

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -73,6 +73,11 @@ output "effective_inspector_enabled" {
   value       = module.baseline.effective_inspector_enabled
 }
 
+output "effective_inspector_resource_types" {
+  description = "Amazon Inspector resource types enabled after profile and override resolution."
+  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+}
+
 output "db_port" {
   description = "Port used by the database (Postgres=5432, MySQL=3306)"
   value       = module.baseline.db_port

--- a/environments/staging/outputs.tf
+++ b/environments/staging/outputs.tf
@@ -75,7 +75,7 @@ output "effective_inspector_enabled" {
 
 output "effective_inspector_resource_types" {
   description = "Amazon Inspector resource types enabled after profile and override resolution."
-  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+  value       = module.baseline.effective_inspector_enabled ? var.inspector_resource_types : []
 }
 
 output "db_port" {

--- a/environments/staging/outputs.tf
+++ b/environments/staging/outputs.tf
@@ -73,6 +73,11 @@ output "effective_inspector_enabled" {
   value       = module.baseline.effective_inspector_enabled
 }
 
+output "effective_inspector_resource_types" {
+  description = "Amazon Inspector resource types enabled after profile and override resolution."
+  value       = module.baseline.effective_inspector_resource_types ? var.inspector_resource_types : []
+}
+
 output "db_port" {
   description = "Port used by the database (Postgres=5432, MySQL=3306)"
   value       = module.baseline.db_port

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -92,6 +92,7 @@ REQUIRED_OUTPUTS=(
   effective_enable_config
   effective_backup_enabled
   effective_inspector_enabled
+  effective_inspector_resource_types
 )
 
 for output_name in "${REQUIRED_OUTPUTS[@]}"; do

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -468,6 +468,7 @@ Security Hub ARN:                   ${SECURITY_HUB_ARN:-<unknown>}
 
 Inspector account status:           ${INSPECTOR_ACCOUNT_STATUS}
 Inspector EC2 status:               ${INSPECTOR_EC2_STATUS}
+Inspector ECR status:               ${INSPECTOR_ECR_STATUS}
 Inspector Lambda status:            ${INSPECTOR_LAMBDA_STATUS}
 Inspector Lambda code status:       ${INSPECTOR_LAMBDA_CODE_STATUS}
 

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -232,10 +232,15 @@ section "Checking Inspector"
 INSPECTOR_ACCOUNT_STATUS_JSON=""
 INSPECTOR_ACCOUNT_STATUS="unknown"
 INSPECTOR_EC2_STATUS="unknown"
+INSPECTOR_ECR_STATUS="unknown"
 INSPECTOR_LAMBDA_STATUS="unknown"
 INSPECTOR_LAMBDA_CODE_STATUS="unknown"
 
 if [[ "$EFFECTIVE_INSPECTOR_ENABLED" == "true" ]]; then
+  if [[ "$EFFECTIVE_INSPECTOR_RESOURCE_TYPE_COUNT" -eq 0 ]]; then
+    fail "effective_inspector_enabled=true, but effective_inspector_resource_types is empty"
+  fi
+
   INSPECTOR_ACCOUNT_STATUS_JSON="$(
     aws inspector2 batch-get-account-status \
       "${aws_args[@]}" \
@@ -251,6 +256,11 @@ if [[ "$EFFECTIVE_INSPECTOR_ENABLED" == "true" ]]; then
   INSPECTOR_EC2_STATUS="$(
     echo "$INSPECTOR_ACCOUNT_STATUS_JSON" |
       jq -r '.accounts[0].resourceState.ec2.status // "unknown"'
+  )"
+
+  INSPECTOR_ECR_STATUS="$(
+    echo "$INSPECTOR_ACCOUNT_STATUS_JSON" |
+      jq -r '.accounts[0].resourceState.ecr.status // "unknown"'
   )"
 
   INSPECTOR_LAMBDA_STATUS="$(
@@ -270,11 +280,45 @@ if [[ "$EFFECTIVE_INSPECTOR_ENABLED" == "true" ]]; then
     fail "Inspector was expected to be enabled, but account status is: ${INSPECTOR_ACCOUNT_STATUS}"
   fi
 
-  info "Inspector EC2 status: $INSPECTOR_EC2_STATUS"
-  info "Inspector Lambda status: $INSPECTOR_LAMBDA_STATUS"
-  info "Inspector Lambda code status: $INSPECTOR_LAMBDA_CODE_STATUS"
+  inspector_resource_expected() {
+    local resource_type="$1"
+
+    echo "$EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON" |
+      jq -e --arg resource_type "$resource_type" 'index($resource_type) != null' >/dev/null
+  }
+
+  validate_inspector_resource_status() {
+    local resource_type="$1"
+    local actual_status="$2"
+
+    if inspector_resource_expected "$resource_type"; then
+      if [[ "$actual_status" == "ENABLED" ]]; then
+        success "Inspector ${resource_type} scanning is enabled as expected"
+      else
+        echo "$INSPECTOR_ACCOUNT_STATUS_JSON" | jq .
+        fail "Inspector ${resource_type} scanning was expected to be ENABLED, but status is: ${actual_status}"
+      fi
+    else
+      if [[ "$actual_status" == "ENABLED" ]]; then
+        warn "Inspector ${resource_type} scanning is ENABLED but is not listed in effective_inspector_resource_types"
+      else
+        success "Inspector ${resource_type} scanning is not enabled, as expected"
+      fi
+    fi
+  }
+
+  validate_inspector_resource_status "EC2" "$INSPECTOR_EC2_STATUS"
+  validate_inspector_resource_status "ECR" "$INSPECTOR_ECR_STATUS"
+  validate_inspector_resource_status "LAMBDA" "$INSPECTOR_LAMBDA_STATUS"
+  validate_inspector_resource_status "LAMBDA_CODE" "$INSPECTOR_LAMBDA_CODE_STATUS"
+
+  info "Inspector expected resource types: $EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON"
 else
   warn "effective_inspector_enabled=false. Skipping Inspector validation."
+
+  if [[ "$EFFECTIVE_INSPECTOR_RESOURCE_TYPE_COUNT" -gt 0 ]]; then
+    warn "effective_inspector_resource_types is non-empty, but Inspector is disabled: ${EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON}"
+  fi
 fi
 
 section "Checking AWS Config"

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -457,6 +457,7 @@ Name prefix:                        ${NAME_PREFIX}
 effective_enable_config:            ${EFFECTIVE_ENABLE_CONFIG}
 effective_backup_enabled:           ${EFFECTIVE_BACKUP_ENABLED}
 effective_inspector_enabled:        ${EFFECTIVE_INSPECTOR_ENABLED}
+effective_inspector_resource_types: ${EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON}
 
 GuardDuty detector count:           ${GUARDDUTY_DETECTOR_COUNT}
 GuardDuty detector ID:              ${GUARDDUTY_DETECTOR_ID}

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -117,6 +117,21 @@ EFFECTIVE_INSPECTOR_RESOURCE_TYPE_COUNT="$(
     jq 'length'
 )"
 
+if ! echo "$EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON" |
+  jq -e '
+    type == "array"
+    and all(.[]; . as $resource_type | ["EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY"] | index($resource_type))
+  ' >/dev/null; then
+  fail "effective_inspector_resource_types contains unsupported values: ${EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON}"
+fi
+
+if echo "$EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON" |
+  jq -e 'index("LAMBDA_CODE") != null and index("LAMBDA") == null' >/dev/null; then
+  fail "effective_inspector_resource_types includes LAMBDA_CODE without LAMBDA"
+fi
+
+success "effective_inspector_resource_types is valid: ${EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON}"
+
 require_value_in_list "$EFFECTIVE_ENABLE_CONFIG" "true false" "effective_enable_config"
 require_value_in_list "$EFFECTIVE_BACKUP_ENABLED" "true false" "effective_backup_enabled"
 require_value_in_list "$EFFECTIVE_INSPECTOR_ENABLED" "true false" "effective_inspector_enabled"

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -107,6 +107,10 @@ EFFECTIVE_ENABLE_CONFIG="$(get_terraform_output_value "$OUTPUTS_JSON" effective_
 EFFECTIVE_BACKUP_ENABLED="$(get_terraform_output_value "$OUTPUTS_JSON" effective_backup_enabled)"
 EFFECTIVE_INSPECTOR_ENABLED="$(get_terraform_output_value "$OUTPUTS_JSON" effective_inspector_enabled)"
 
+require_value_in_list "$EFFECTIVE_ENABLE_CONFIG" "true false" "effective_enable_config"
+require_value_in_list "$EFFECTIVE_BACKUP_ENABLED" "true false" "effective_backup_enabled"
+require_value_in_list "$EFFECTIVE_INSPECTOR_ENABLED" "true false" "effective_inspector_enabled"
+
 EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON="$(
   echo "$OUTPUTS_JSON" |
     jq -c '.effective_inspector_resource_types.value // []'
@@ -131,10 +135,6 @@ if echo "$EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON" |
 fi
 
 success "effective_inspector_resource_types is valid: ${EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON}"
-
-require_value_in_list "$EFFECTIVE_ENABLE_CONFIG" "true false" "effective_enable_config"
-require_value_in_list "$EFFECTIVE_BACKUP_ENABLED" "true false" "effective_backup_enabled"
-require_value_in_list "$EFFECTIVE_INSPECTOR_ENABLED" "true false" "effective_inspector_enabled"
 
 success "effective_enable_config is valid: $EFFECTIVE_ENABLE_CONFIG"
 success "effective_backup_enabled is valid: $EFFECTIVE_BACKUP_ENABLED"

--- a/scripts/validation/validate-security-services.sh
+++ b/scripts/validation/validate-security-services.sh
@@ -107,6 +107,16 @@ EFFECTIVE_ENABLE_CONFIG="$(get_terraform_output_value "$OUTPUTS_JSON" effective_
 EFFECTIVE_BACKUP_ENABLED="$(get_terraform_output_value "$OUTPUTS_JSON" effective_backup_enabled)"
 EFFECTIVE_INSPECTOR_ENABLED="$(get_terraform_output_value "$OUTPUTS_JSON" effective_inspector_enabled)"
 
+EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON="$(
+  echo "$OUTPUTS_JSON" |
+    jq -c '.effective_inspector_resource_types.value // []'
+)"
+
+EFFECTIVE_INSPECTOR_RESOURCE_TYPE_COUNT="$(
+  echo "$EFFECTIVE_INSPECTOR_RESOURCE_TYPES_JSON" |
+    jq 'length'
+)"
+
 require_value_in_list "$EFFECTIVE_ENABLE_CONFIG" "true false" "effective_enable_config"
 require_value_in_list "$EFFECTIVE_BACKUP_ENABLED" "true false" "effective_backup_enabled"
 require_value_in_list "$EFFECTIVE_INSPECTOR_ENABLED" "true false" "effective_inspector_enabled"


### PR DESCRIPTION
Closes #471 - Update scripts/validation/validate-security-services.sh to reflect updates to Inspector (only scan EC2 by default)