### PR TITLE
feat: Create `export-report.sh` to capture per-script validation and generate machine-readable and client-facing summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,4 @@ build/
 # Generated validation evidence/reports
 ########################################
 
-validation/results
+validation-results/

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -67,3 +67,12 @@ for script_name in "${VALIDATION_SCRIPTS[@]}"; do
 done
 
 section "Validation report export summary"
+info "Output directory: ${OUTPUT_DIR}"
+info "Validation scripts passed: ${PASSED_COUNT}/${TOTAL_COUNT}"
+info "Validation scripts failed: ${FAILED_COUNT}/${TOTAL_COUNT}"
+
+if [[ "$FAILED_COUNT" -gt 0 ]]; then
+  fail "One or more validation scripts failed. Review logs in ${OUTPUT_DIR}"
+fi
+
+success "Validation report logs exported successfully"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -220,7 +220,7 @@ section "Generating Markdown summary"
   echo "## Executive Summary"
   echo
   echo "| Field | Value |"
-  echo "|---|---|
+  echo "|---|---|"
   echo "| Overall result | **${OVERALL_RESULT}** |"
   echo "| Validation scripts passed | **${PASSED_COUNT}/${TOTAL_COUNT}** |"
   echo "| Validation scripts failed | **${FAILED_COUNT}/${TOTAL_COUNT}** |"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -215,7 +215,7 @@ section "Generating Markdown summary"
 {
   echo "# tf-secure-baseline Validation Report"
   echo
-  echo "The `dev` workload environment passed automated read-only validation."
+  echo "The `${ENV_NAME}` workload environment passed automated read-only validation."
   echo
   echo "## Executive Summary"
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/common.sh"
+
+ENV_NAME="${1:-}"
+
+if [[ -z "ENV_NAME" ]]; then
+  fail "Usage: $0 <dev|staging|prod>"
+fi
+
+require_env_name "$ENV_NAME"
+
+REPO_ROOT="$(get_repo_root)"
+TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
+OUTPUT_DIR="${REPO_ROOT}/validation-results/${ENV_NAME}/${TIMESTAMP}"
+
+VALIDATION_SCRIPTS=(
+  "validate-env.sh"
+  "validate-networking.sh"
+  "validate-vpc-endpoints.sh"
+  "validate-logging.sh"
+  "validate-security-services.sh"
+  "validate-kms.sh"
+  "validate-backup.sh"
+  "validate-sns.sh"
+  "validate-sqs.sh"
+  "validate-eventbridge.sh"
+  "validate-lambda.sh"
+  "validate-ssm.sh"
+  "validate-compute.sh"
+  "validate-iam.sh"
+)
+
+FAILED_COUNT=0
+PASSED_COUNT=0
+TOTAL_COUNT="${#VALIDATION_SCRIPTS[@]}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -215,7 +215,7 @@ section "Generating Markdown summary"
 {
   echo "# tf-secure-baseline Validation Report"
   echo
-  echo "This report summarizes automated read-only validation results for the `$ENV_NAME` workload environment."
+  echo "This report summarizes automated read-only validation results for the \`$ENV_NAME\` workload environment."
   echo
   echo "## Executive Summary"
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -18,6 +18,11 @@ require_env_name "$ENV_NAME"
 
 NAME_PREFIX="${NAME_PREFIX:-tf-secure-baseline-${ENV_NAME}}"
 
+if [[ "$NAME_PREFIX" != *"-${ENV_NAME}" ]]; then
+  warn "NAME_PREFIX does not end with -${ENV_NAME}: ${NAME_PREFIX}"
+  warn "This may be valid for custom/client deployments, but confirm it matches deployed resource names."
+fi
+
 info "Environment: ${ENV_NAME}"
 info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
 info "AWS_REGION: ${AWS_REGION}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -215,7 +215,7 @@ section "Generating Markdown summary"
 {
   echo "# tf-secure-baseline Validation Report"
   echo
-  echo "The `${ENV_NAME}` workload environment passed automated read-only validation."
+  echo "This report summarizes automated read-only validation results for the `$ENV_NAME` workload environment."
   echo
   echo "## Executive Summary"
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -6,12 +6,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ENV_NAME="${1:-}"
+AWS_PROFILE="${AWS_PROFILE:-}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+EXPECTED_ACCOUNT_ID="${EXPECTED_ACCOUNT_ID:-}"
 
 if [[ -z "$ENV_NAME" ]]; then
   fail "Usage: $0 <dev|staging|prod>"
 fi
 
 require_env_name "$ENV_NAME"
+
+NAME_PREFIX="${NAME_PREFIX:-tf-secure-baseline-${ENV_NAME}}"
+
+info "Environment: ${ENV_NAME}"
+info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
+info "AWS_REGION: ${AWS_REGION}"
+info "EXPECTED_ACCOUNT_ID: ${EXPECTED_ACCOUNT_ID:-<not set>}"
+info "NAME_PREFIX: ${NAME_PREFIX}"
 
 REPO_ROOT="$(get_repo_root)"
 TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -219,9 +219,11 @@ section "Generating Markdown summary"
   echo
   echo "## Executive Summary"
   echo
-  echo "Overall result: **${OVERALL_RESULT}**"
-  echo "Validation scripts passed: **${PASSED_COUNT}/${TOTAL_COUNT}**"
-  echo "Validation scripts failed: **${FAILED_COUNT}/${TOTAL_COUNT}**"
+  echo "| Field | Value |"
+  echo "|---|---|
+  echo "| Overall result | **${OVERALL_RESULT}** |"
+  echo "| Validation scripts passed | **${PASSED_COUNT}/${TOTAL_COUNT}** |"
+  echo "| Validation scripts failed | **${FAILED_COUNT}/${TOTAL_COUNT}** |"
   echo
   echo "## Environment"
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -36,3 +36,34 @@ VALIDATION_SCRIPTS=(
 FAILED_COUNT=0
 PASSED_COUNT=0
 TOTAL_COUNT="${#VALIDATION_SCRIPTS[@]}"
+
+section "Exporting validation report"
+info "Environment: ${ENV_NAME}"
+info "Output directory: ${OUTPUT_DIR}"
+
+for script_name in "${VALIDATION_SCRIPTS[@]}"; do
+  script_path="${SCRIPT_DIR}/${script_name}"
+  log_file="${OUTPUT_DIR}/${script_name%.sh}.log"
+
+  section "Running ${script_name}"
+
+  if [[ ! -x "$script_path" ]]; then
+    warn "${script_name} is missing or not executable"
+    {
+      echo "[FAIL] Validation script is missing or not executable: ${script_path}"
+    } > "$log_file"
+
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    continue
+  fi
+
+  if "$script_path" "$ENV_NAME" > "$log_file" 2>&1; then
+    success "${script_name} passed"
+    PASSED_COUNT=$((PASSED_COUNT + 1))
+  else
+    warn "${script_name} failed. See log: ${log_file}"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+  fi
+done
+
+section "Validation report export summary"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -7,7 +7,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 
 ENV_NAME="${1:-}"
 
-if [[ -z "ENV_NAME" ]]; then
+if [[ -z "$ENV_NAME" ]]; then
   fail "Usage: $0 <dev|staging|prod>"
 fi
 

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -224,7 +224,7 @@ section "Generating Markdown summary"
   echo "| AWS Profile | ${AWS_PROFILE:-<default>} |"
   echo "| AWS Region | ${AWS_REGION} |"
   echo "| AWS Account ID | ${AWS_ACCOUNT_ID} |"
-  echo "| Expected Account ID | ${EXPECTED_ACCOUNT_ID} |"
+  echo "| Expected Account ID | ${EXPECTED_ACCOUNT_ID:-<not set>} |"
   echo "| Name Prefix | ${NAME_PREFIX} |"
   echo "| Validation Time | ${VALIDATION_TIME} |"
   echo "| Overall Result | ${OVERALL_RESULT} |"
@@ -239,6 +239,35 @@ section "Generating Markdown summary"
   jq -r '
     .results[]
     | "| \(.area) | `\(.script)` | \(.result) | `\(.log_file)` |"
+  ' "$SUMMARY_JSON"
+
+  echo
+  echo "## Manual Validation Remaining"
+  echo
+  echo "The automated validation suite is intentionally read-only. The following checks remain manual:"
+  echo
+  echo "- Control-plane resource validation"
+  echo "- IAM Identity Center assignment validation"
+  echo "- GitHub Actions workflow validation"
+  echo "- Live EC2 isolation test"
+  echo "- Live EC2 rollback test"
+  echo "- Live IP enrichment test"
+  echo "- Tamper detection test"
+  echo "- Break-glass role assumption test"
+  echo "- Destroy safety review"
+  echo
+  echo "## Evidence Files"
+  echo
+  echo "This report directory contains the generated validation summary files and per-script logs."
+  echo
+  echo "| File | Purpose |"
+  echo "|---|---|"
+  echo "| \`summary.md\` | Human-readable validation report |"
+  echo "| \`summary.json\` | Machine-readable validation summary |"
+
+  jq -r '
+    .results[]
+    | "| `\(.log_file)` | Log output for `\(.script)` |"
   ' "$SUMMARY_JSON"
 
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -33,6 +33,9 @@ REPO_ROOT="$(get_repo_root)"
 TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 OUTPUT_DIR="${REPO_ROOT}/validation-results/${ENV_NAME}/${TIMESTAMP}"
 
+RESULTS_JSONL="$(mktemp)"
+trap 'rm -f "$RESULTS_JSONL"' EXIT
+
 mkdir -p "$OUTPUT_DIR"
 
 VALIDATION_SCRIPTS=(
@@ -74,7 +77,6 @@ PASSED_COUNT=0
 TOTAL_COUNT="${#VALIDATION_SCRIPTS[@]}"
 
 section "Exporting validation report"
-info "Environment: ${ENV_NAME}"
 info "Output directory: ${OUTPUT_DIR}"
 
 for script_name in "${VALIDATION_SCRIPTS[@]}"; do

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -263,7 +263,7 @@ echo "Name prefix:                ${NAME_PREFIX}"
 echo
 echo "Output directory:           ${OUTPUT_DIR}"
 echo "Summary JSON:               ${SUMMARY_JSON}"
-echo "Summary Markdown: ${SUMMARY_MD}"
+echo "Summary Markdown:           ${SUMMARY_MD}"
 echo
 echo "Validation scripts passed:  ${PASSED_COUNT}/${TOTAL_COUNT}"
 echo "Validation scripts failed:  ${FAILED_COUNT}/${TOTAL_COUNT}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -215,6 +215,15 @@ section "Generating Markdown summary"
 {
   echo "# tf-secure-baseline Validation Report"
   echo
+  echo "The `dev` workload environment passed automated read-only validation."
+  echo
+  echo "## Executive Summary"
+  echo
+  echo "Overall result: ${OVERALL_RESULT}"
+  echo "Validation scripts passed: ${PASSED_COUNT}/${TOTAL_COUNT}"
+  echo "Validation scripts failed: ${FAILED_COUNT}/${TOTAL_COUNT}"
+  echo
+  echo
   echo "## Environment"
   echo
   echo "| Field | Value |"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -16,6 +16,8 @@ REPO_ROOT="$(get_repo_root)"
 TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 OUTPUT_DIR="${REPO_ROOT}/validation-results/${ENV_NAME}/${TIMESTAMP}"
 
+mkdir -p "$OUTPUT_DIR"
+
 VALIDATION_SCRIPTS=(
   "validate-env.sh"
   "validate-networking.sh"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -223,7 +223,6 @@ section "Generating Markdown summary"
   echo "Validation scripts passed: ${PASSED_COUNT}/${TOTAL_COUNT}"
   echo "Validation scripts failed: ${FAILED_COUNT}/${TOTAL_COUNT}"
   echo
-  echo
   echo "## Environment"
   echo
   echo "| Field | Value |"
@@ -280,13 +279,13 @@ section "Generating Markdown summary"
   ' "$SUMMARY_JSON"
 
   echo
-  echo "## Notes"
+  echo "## Limitations"
   echo
-  echo "This report validates deployed AWS control presence and configuration for the selected workload environment."
+  echo "This report validates deployed AWS control presence and selected configuration settings for the target workload environment."
   echo
   echo "The validation suite confirms the presence and configuration of selected AWS security controls in the deployed environment."
   echo
-  echo "The validation suite does not replace a full SOC 2 or ISO 27001 audit, control owner review, policy review, evidence review, risk assessment, or ISMS."
+  echo "This report does not replace a full SOC 2 or ISO 27001 audit, control owner review, policy review, evidence review, risk assessment, or ISMS."
 } > "$SUMMARY_MD"
 
 success "Markdown summary written: ${SUMMARY_MD}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -18,23 +18,12 @@ require_env_name "$ENV_NAME"
 
 NAME_PREFIX="${NAME_PREFIX:-tf-secure-baseline-${ENV_NAME}}"
 
-if [[ "$NAME_PREFIX" != *"-${ENV_NAME}" ]]; then
-  warn "NAME_PREFIX does not end with -${ENV_NAME}: ${NAME_PREFIX}"
-  warn "This may be valid for custom/client deployments, but confirm it matches deployed resource names."
-fi
-
-info "Environment: ${ENV_NAME}"
-info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
-info "AWS_REGION: ${AWS_REGION}"
-info "EXPECTED_ACCOUNT_ID: ${EXPECTED_ACCOUNT_ID:-<not set>}"
-info "NAME_PREFIX: ${NAME_PREFIX}"
+VALIDATION_TIME="$(date +"%Y-%m-%dT%H:%M:%S%z")"
+TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 
 REPO_ROOT="$(get_repo_root)"
-TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 OUTPUT_DIR="${REPO_ROOT}/validation-results/${ENV_NAME}/${TIMESTAMP}"
-
-RESULTS_JSONL="$(mktemp)"
-trap 'rm -f "$RESULTS_JSONL"' EXIT
+SUMMARY_JSON="${OUTPUT_DIR}/summary.json"
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -72,45 +61,173 @@ declare -A VALIDATION_AREAS=(
   ["validate-iam.sh"]="IAM"
 )
 
-FAILED_COUNT=0
+RESULTS_JSONL="$(mktemp)"
+trap 'rm -f "$RESULTS_JSONL"' EXIT
+
 PASSED_COUNT=0
+FAILED_COUNT=0
 TOTAL_COUNT="${#VALIDATION_SCRIPTS[@]}"
 
-section "Exporting validation report"
-info "Output directory: ${OUTPUT_DIR}"
+section "tf-secure-baseline Validation Report Export"
 
-for script_name in "${VALIDATION_SCRIPTS[@]}"; do
-  script_path="${SCRIPT_DIR}/${script_name}"
-  log_file="${OUTPUT_DIR}/${script_name%.sh}.log"
+section "Checking required local commands"
 
-  section "Running ${script_name}"
+require_command "aws"
+success "aws CLI found"
 
-  if [[ ! -x "$script_path" ]]; then
-    warn "${script_name} is missing or not executable"
-    {
-      echo "[FAIL] Validation script is missing or not executable: ${script_path}"
-    } > "$log_file"
+require_command "terraform"
+success "terraform found"
 
-    FAILED_COUNT=$((FAILED_COUNT + 1))
-    continue
-  fi
+require_command "jq"
+success "jq found"
 
-  if "$script_path" "$ENV_NAME" >"$log_file" 2>&1; then
-    success "${script_name} passed"
-    PASSED_COUNT=$((PASSED_COUNT + 1))
-  else
-    warn "${script_name} failed. See log: ${log_file}"
-    FAILED_COUNT=$((FAILED_COUNT + 1))
-  fi
-done
+require_command "git"
+success "git found"
 
-section "Validation report export summary"
-info "Output directory: ${OUTPUT_DIR}"
-info "Validation scripts passed: ${PASSED_COUNT}/${TOTAL_COUNT}"
-info "Validation scripts failed: ${FAILED_COUNT}/${TOTAL_COUNT}"
+section "Resolving repository paths and report settings"
 
-if [[ "$FAILED_COUNT" -gt 0 ]]; then
-  fail "One or more validation scripts failed. Review logs in ${OUTPUT_DIR}"
+info "Repository root: ${REPO_ROOT}"
+info "Environment: ${ENV_NAME}"
+info "Output dir: ${OUTPUT_DIR}"
+info "Name prefix: ${NAME_PREFIX}"
+info "AWS_PROFILE: ${AWS_PROFILE:-<default>}"
+info "AWS_REGION: ${AWS_REGION}"
+info "EXPECTED_ACCOUNT_ID: ${EXPECTED_ACCOUNT_ID:-<not set>}"
+info "Validation time: ${VALIDATION_TIME}"
+
+if [[ "$NAME_PREFIX" != *"-${ENV_NAME}" ]]; then
+  warn "NAME_PREFIX does not end with -${ENV_NAME}: ${NAME_PREFIX}"
+  warn "This may be valid for custom/client deployments, but confirm it matches deployed resource names."
 fi
 
-success "Validation report logs exported successfully"
+section "Checking AWS caller identity"
+
+AWS_ACCOUNT_ID="$(get_aws_account_id "$AWS_PROFILE" "$AWS_REGION")"
+AWS_CALLER_ARN="$(get_aws_caller_arn "$AWS_PROFILE" "$AWS_REGION")"
+
+success "AWS credentials are valid"
+info "AWS account ID: ${AWS_ACCOUNT_ID}"
+info "AWS caller ARN: ${AWS_CALLER_ARN}"
+
+if [[ -n "$EXPECTED_ACCOUNT_ID" ]]; then
+  if [[ "$AWS_ACCOUNT_ID" == "$EXPECTED_ACCOUNT_ID" ]]; then
+    success "AWS account ID matches expected account: ${EXPECTED_ACCOUNT_ID}"
+  else
+    fail "AWS account ID mismatch. Expected ${EXPECTED_ACCOUNT_ID}, got ${AWS_ACCOUNT_ID}"
+  fi
+fi
+
+section "Running validation scripts"
+
+for SCRIPT_NAME in "${VALIDATION_SCRIPTS[@]}"; do
+  AREA="${VALIDATION_AREAS[$SCRIPT_NAME]:-$SCRIPT_NAME}"
+  SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_NAME}"
+  LOG_FILE="${OUTPUT_DIR}/${SCRIPT_NAME%.sh}.log"
+  LOG_BASENAME="$(basename "$LOG_FILE")"
+  RESULT="FAIL"
+
+  info "Running ${SCRIPT_NAME}"
+
+  if [[ ! -x "$SCRIPT_PATH" ]]; then
+    warn "${SCRIPT_NAME} is missing or not executable"
+
+    {
+      echo "[FAIL] Validation script is missing or not executable: ${SCRIPT_PATH}"
+    } > "$LOG_FILE"
+
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    RESULT="FAIL"
+  elif "$SCRIPT_PATH" "$ENV_NAME" >"$LOG_FILE" 2>&1; then
+    success "${SCRIPT_NAME} passed"
+    PASSED_COUNT=$((PASSED_COUNT + 1))
+    RESULT="PASS"
+  else
+    warn "${SCRIPT_NAME} failed. See log: ${LOG_FILE}"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    RESULT="FAIL"
+  fi
+
+  jq -n \
+    --arg area "$AREA" \
+    --arg script "$SCRIPT_NAME" \
+    --arg result "$RESULT" \
+    --arg log_file "$LOG_BASENAME" \
+    '{
+      area: $area,
+      script: $script,
+      result: $result,
+      log_file: $log_file
+    }' >> "$RESULTS_JSONL"
+done
+
+if [[ "$FAILED_COUNT" -gt 0 ]]; then
+  OVERALL_RESULT="FAIL"
+else
+  OVERALL_RESULT="PASS"
+fi
+
+section "Generating JSON summary"
+
+jq -n \
+  --arg project "tf-secure-baseline" \
+  --arg environment "$ENV_NAME" \
+  --arg aws_profile "$AWS_PROFILE" \
+  --arg aws_region "$AWS_REGION" \
+  --arg aws_account_id "$AWS_ACCOUNT_ID" \
+  --arg expected_account_id "$EXPECTED_ACCOUNT_ID" \
+  --arg name_prefix "$NAME_PREFIX" \
+  --arg validation_time "$VALIDATION_TIME" \
+  --arg overall_result "$OVERALL_RESULT" \
+  --argjson scripts_passed "$PASSED_COUNT" \
+  --argjson scripts_failed "$FAILED_COUNT" \
+  --slurpfile results "$RESULTS_JSONL" \
+  '{
+    project: $project,
+    environment: $environment,
+    aws_profile: $aws_profile,
+    aws_region: $aws_region,
+    aws_account_id: $aws_account_id,
+    expected_account_id: $expected_account_id,
+    name_prefix: $name_prefix,
+    validation_time: $validation_time,
+    overall_result: $overall_result,
+    scripts_passed: $scripts_passed,
+    scripts_failed: $scripts_failed,
+    results: $results,
+    manual_validation_remaining: [
+      "control_plane",
+      "identity_center_assignments",
+      "github_actions_workflows",
+      "live_ec2_isolation",
+      "live_ec2_rollback",
+      "live_ip_enrichment",
+      "tamper_detection",
+      "break_glass",
+      "destroy_safety"
+    ]
+  }' > "$SUMMARY_JSON"
+
+success "JSON summary written: ${SUMMARY_JSON}"
+
+section "Validation Report Export Summary"
+
+echo "Environment:                ${ENV_NAME}"
+echo "AWS profile:                ${AWS_PROFILE:-<default>}"
+echo "AWS region:                 ${AWS_REGION}"
+echo "AWS account ID:             ${AWS_ACCOUNT_ID}"
+echo "Name prefix:                ${NAME_PREFIX}"
+echo
+echo "Output directory:           ${OUTPUT_DIR}"
+echo "Summary JSON:               ${SUMMARY_JSON}"
+echo
+echo "Validation scripts passed:  ${PASSED_COUNT}/${TOTAL_COUNT}"
+echo "Validation scripts failed:  ${FAILED_COUNT}/${TOTAL_COUNT}"
+echo "Overall result:             ${OVERALL_RESULT}"
+
+section "Validation Result"
+
+if [[ "$FAILED_COUNT" -gt 0 ]]; then
+  fail "Validation report export completed with failures for: ${ENV_NAME}"
+fi
+
+success "Validation report export completed successfully for: ${ENV_NAME}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -57,7 +57,7 @@ for script_name in "${VALIDATION_SCRIPTS[@]}"; do
     continue
   fi
 
-  if "$script_path" "$ENV_NAME" > "$log_file" 2>&1; then
+  if "$script_path" "$ENV_NAME" >"$log_file" 2>&1; then
     success "${script_name} passed"
     PASSED_COUNT=$((PASSED_COUNT + 1))
   else

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -18,7 +18,7 @@ require_env_name "$ENV_NAME"
 
 NAME_PREFIX="${NAME_PREFIX:-tf-secure-baseline-${ENV_NAME}}"
 
-VALIDATION_TIME="$(date +"%Y-%m-%dT%H:%M:%S%z")"
+VALIDATION_TIME="$(date +"%Y-%m-%dT%H:%M:%S%:z")"
 TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 
 REPO_ROOT="$(get_repo_root)"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -52,6 +52,23 @@ VALIDATION_SCRIPTS=(
   "validate-iam.sh"
 )
 
+declare -A VALIDATION_AREAS=(
+  ["validate-env.sh"]="Environment"
+  ["validate-networking.sh"]="Networking"
+  ["validate-vpc-endpoints.sh"]="VPC Endpoints"
+  ["validate-logging.sh"]="Logging"
+  ["validate-security-services.sh"]="Security Services"
+  ["validate-kms.sh"]="KMS"
+  ["validate-backup.sh"]="Backup"
+  ["validate-sns.sh"]="SNS"
+  ["validate-sqs.sh"]="SQS"
+  ["validate-eventbridge.sh"]="EventBridge"
+  ["validate-lambda.sh"]="Lambda"
+  ["validate-ssm.sh"]="SSM"
+  ["validate-compute.sh"]="Compute"
+  ["validate-iam.sh"]="IAM"
+)
+
 FAILED_COUNT=0
 PASSED_COUNT=0
 TOTAL_COUNT="${#VALIDATION_SCRIPTS[@]}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -24,6 +24,7 @@ TIMESTAMP="$(date +"%Y-%m-%dT%H%M%S")"
 REPO_ROOT="$(get_repo_root)"
 OUTPUT_DIR="${REPO_ROOT}/validation-results/${ENV_NAME}/${TIMESTAMP}"
 SUMMARY_JSON="${OUTPUT_DIR}/summary.json"
+SUMMARY_MD="${OUTPUT_DIR}/summary.md"
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -208,6 +209,49 @@ jq -n \
   }' > "$SUMMARY_JSON"
 
 success "JSON summary written: ${SUMMARY_JSON}"
+
+section "Generating Markdown summary"
+
+{
+  echo "# tf-secure-baseline Validation Report"
+  echo
+  echo "## Environment"
+  echo
+  echo "| Field | Value |"
+  echo "|---|---|"
+  echo "| Project | tf-secure-baseline |"
+  echo "| Environment | ${ENV_NAME} |"
+  echo "| AWS Profile | ${AWS_PROFILE:-<default>} |"
+  echo "| AWS Region | ${AWS_REGION} |"
+  echo "| AWS Account ID | ${AWS_ACCOUNT_ID} |"
+  echo "| Expected Account ID | ${EXPECTED_ACCOUNT_ID} |"
+  echo "| Name Prefix | ${NAME_PREFIX} |"
+  echo "| Validation Time | ${VALIDATION_TIME} |"
+  echo "| Overall Result | ${OVERALL_RESULT} |"
+  echo "| Scripts Passed | ${PASSED_COUNT}/${TOTAL_COUNT} |"
+  echo "| Scripts Failed | ${FAILED_COUNT}/${TOTAL_COUNT} |"
+  echo
+  echo "## Validation Summary"
+  echo
+  echo "| Area | Script | Result | Log |"
+  echo "|---|---|---|---|"
+
+  jq -r '
+    .results[]
+    | "| \(.area) | `\(.script)` | \(.result) | `\(.log_file)` |"
+  ' "$SUMMARY_JSON"
+
+  echo
+  echo "## Notes"
+  echo
+  echo "This report validates deployed AWS control presence and configuration for the selected workload environment."
+  echo
+  echo "The validation suite confirms the presence and configuration of selected AWS security controls in the deployed environment."
+  echo
+  echo "The validation suite does not replace a full SOC 2 or ISO 27001 audit, control owner review, policy review, evidence review, risk assessment, or ISMS."
+} > "$SUMMARY_MD"
+
+success "Markdown summary written: ${SUMMARY_MD}"
 
 section "Validation Report Export Summary"
 

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/lib/common.sh"
 
 ENV_NAME="${1:-}"

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -219,9 +219,9 @@ section "Generating Markdown summary"
   echo
   echo "## Executive Summary"
   echo
-  echo "Overall result: ${OVERALL_RESULT}"
-  echo "Validation scripts passed: ${PASSED_COUNT}/${TOTAL_COUNT}"
-  echo "Validation scripts failed: ${FAILED_COUNT}/${TOTAL_COUNT}"
+  echo "Overall result: **${OVERALL_RESULT}**"
+  echo "Validation scripts passed: **${PASSED_COUNT}/${TOTAL_COUNT}**"
+  echo "Validation scripts failed: **${FAILED_COUNT}/${TOTAL_COUNT}**"
   echo
   echo "## Environment"
   echo

--- a/scripts/validation/export-report.sh
+++ b/scripts/validation/export-report.sh
@@ -263,6 +263,7 @@ echo "Name prefix:                ${NAME_PREFIX}"
 echo
 echo "Output directory:           ${OUTPUT_DIR}"
 echo "Summary JSON:               ${SUMMARY_JSON}"
+echo "Summary Markdown: ${SUMMARY_MD}"
 echo
 echo "Validation scripts passed:  ${PASSED_COUNT}/${TOTAL_COUNT}"
 echo "Validation scripts failed:  ${FAILED_COUNT}/${TOTAL_COUNT}"

--- a/scripts/validation/validate-env.sh
+++ b/scripts/validation/validate-env.sh
@@ -20,6 +20,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 ENV_NAME="${1:-}"
 AWS_PROFILE="${AWS_PROFILE:-}"
 AWS_REGION="${AWS_REGION:-us-east-1}"
+NAME_PREFIX="${NAME_PREFIX:-tf-secure-baseline-${ENV_NAME:-unknown}}"
 EXPECTED_ACCOUNT_ID="${EXPECTED_ACCOUNT_ID:-}"
 
 export AWS_PAGER=""


### PR DESCRIPTION
Closes #476 - Capture per-script validation
Closes #475 - Add export-report.sh validation reporting wrapper
Closes #477 - Generate machine-readable summary
Closes #478 - Generate client-facing summary.md