### PR TITLE
feat: Create and configure EC2-Isolation, EC2-Rollback, and IP-Enrichment Lambda function DLQs

### DIFF
--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -106,6 +106,7 @@ module "iam" {
 
   threat_intel_api_keys_arn          = module.automation.threat_intel_api_keys_arn
   lambda_ip_enrichment_log_group_arn = module.automation.lambda_ip_enrichment_log_group_arn
+  lambda_ec2_isolation_dlq_arn = module.automation.lambda_ec2_isolation_dlq_arn
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
 }
 

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -97,6 +97,7 @@ module "iam" {
   cloudtrail_log_group_arn = module.logging.cloudtrail_log_group_arn
   secops_topic_arn         = module.monitoring.secops_topic_arn
   logs_cmk_arn             = module.security.logs_cmk_arn
+  secrets_manager_cmk_arn            = module.security.secrets_manager_cmk_arn
 
   centralized_logs_bucket_arn           = module.storage.centralized_logs_bucket_arn
   flowlogs_firehose_delivery_stream_arn = module.logging.flowlogs_firehose_delivery_stream_arn
@@ -105,7 +106,6 @@ module "iam" {
 
   threat_intel_api_keys_arn          = module.automation.threat_intel_api_keys_arn
   lambda_ip_enrichment_log_group_arn = module.automation.lambda_ip_enrichment_log_group_arn
-  secrets_manager_cmk_arn            = module.security.secrets_manager_cmk_arn
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
 }
 

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -109,6 +109,7 @@ module "iam" {
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
 
   lambda_ec2_isolation_dlq_arn       = module.automation.lambda_ec2_isolation_dlq_arn
+  lambda_ec2_rollback_dlq_arn = module.automation.lambda_ec2_rollback_dlq_arn
 }
 
 module "security" {

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -108,8 +108,8 @@ module "iam" {
   lambda_ip_enrichment_log_group_arn = module.automation.lambda_ip_enrichment_log_group_arn
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
 
-  lambda_ec2_isolation_dlq_arn       = module.automation.lambda_ec2_isolation_dlq_arn
-  lambda_ec2_rollback_dlq_arn = module.automation.lambda_ec2_rollback_dlq_arn
+  lambda_ec2_isolation_dlq_arn = module.automation.lambda_ec2_isolation_dlq_arn
+  lambda_ec2_rollback_dlq_arn  = module.automation.lambda_ec2_rollback_dlq_arn
 }
 
 module "security" {

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -97,7 +97,7 @@ module "iam" {
   cloudtrail_log_group_arn = module.logging.cloudtrail_log_group_arn
   secops_topic_arn         = module.monitoring.secops_topic_arn
   logs_cmk_arn             = module.security.logs_cmk_arn
-  secrets_manager_cmk_arn            = module.security.secrets_manager_cmk_arn
+  secrets_manager_cmk_arn  = module.security.secrets_manager_cmk_arn
 
   centralized_logs_bucket_arn           = module.storage.centralized_logs_bucket_arn
   flowlogs_firehose_delivery_stream_arn = module.logging.flowlogs_firehose_delivery_stream_arn
@@ -106,7 +106,7 @@ module "iam" {
 
   threat_intel_api_keys_arn          = module.automation.threat_intel_api_keys_arn
   lambda_ip_enrichment_log_group_arn = module.automation.lambda_ip_enrichment_log_group_arn
-  lambda_ec2_isolation_dlq_arn = module.automation.lambda_ec2_isolation_dlq_arn
+  lambda_ec2_isolation_dlq_arn       = module.automation.lambda_ec2_isolation_dlq_arn
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
 }
 

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -110,6 +110,7 @@ module "iam" {
 
   lambda_ec2_isolation_dlq_arn = module.automation.lambda_ec2_isolation_dlq_arn
   lambda_ec2_rollback_dlq_arn  = module.automation.lambda_ec2_rollback_dlq_arn
+  lambda_ip_enrichment_dlq_arn = module.automation.lambda_ip_enrichment_dlq_arn
 }
 
 module "security" {

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -106,8 +106,9 @@ module "iam" {
 
   threat_intel_api_keys_arn          = module.automation.threat_intel_api_keys_arn
   lambda_ip_enrichment_log_group_arn = module.automation.lambda_ip_enrichment_log_group_arn
-  lambda_ec2_isolation_dlq_arn       = module.automation.lambda_ec2_isolation_dlq_arn
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
+
+  lambda_ec2_isolation_dlq_arn       = module.automation.lambda_ec2_isolation_dlq_arn
 }
 
 module "security" {

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -213,15 +213,15 @@ resource "aws_sqs_queue_policy" "ec2_isolation_dlq" {
 
 ### EC2 ISOLATION CLOUDWATCH ALARM
 resource "aws_cloudwatch_metric_alarm" "ec2_isolation_dlq_visible_messages" {
-  alarm_name = "${var.name_prefix}-ec2-isolation-dlq-visible-messages"
+  alarm_name          = "${var.name_prefix}-ec2-isolation-dlq-visible-messages"
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods = 1
-  metric_name = "ApproximateNumberOfMessagesVisible"
-  namespace = "AWS/SQS"
-  period = 300
-  statistic = "Maximum"
-  threshold = 0
-  treat_missing_data = "notBreaching"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     QueueName = aws_sqs_queue.ec2_isolation_dlq.name
@@ -232,9 +232,9 @@ resource "aws_cloudwatch_metric_alarm" "ec2_isolation_dlq_visible_messages" {
   ]
 
   tags = {
-    Name = "${var.name_prefix}-EC2-Isolation-DLQ-Visible-Messages"
+    Name        = "${var.name_prefix}-EC2-Isolation-DLQ-Visible-Messages"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 }
 

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -116,6 +116,20 @@ resource "aws_lambda_permission" "allow_eventbridge_ec2_isolation" {
   source_arn    = aws_cloudwatch_event_rule.securityhub_ec2_high_critical.arn
 }
 
+### ENABLE EC2 ISOLATION LAMBDA PROCESSING FAILURES TO LAND IN ITS DLQ
+resource "aws_lambda_function_event_invoke_config" "ec2_isolation" {
+  function_name = aws_lambda_function.ec2_isolation.function_name
+
+  maximum_event_age_in_seconds = 3600
+  maximum_retry_attempts = 2
+
+  destination_config {
+    on_failure {
+      destination = aws_sqs_queue.ec2_isolation_dlq.arn
+    }
+  }
+}
+
 ## CLOUDWATCH LOG GROUP FOR EC2 ISOLATION LAMBDA
 resource "aws_cloudwatch_log_group" "lambda_ec2_isolation" {
   name              = "/aws/lambda/${var.name_prefix}-ec2-isolation"

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_log_group" "lambda_ec2_isolation" {
   }
 }
 
-## EC2 ISOLATION DLQ
+## EC2 ISOLATION LAMBDA DLQ
 resource "aws_sqs_queue" "ec2_isolation_dlq" {
   name              = "${var.name_prefix}-ec2-isolation-dlq"
   kms_master_key_id = var.logs_cmk_arn
@@ -211,7 +211,7 @@ resource "aws_sqs_queue_policy" "ec2_isolation_dlq" {
   policy    = data.aws_iam_policy_document.ec2_isolation_dlq_policy.json
 }
 
-### EC2 ISOLATION CLOUDWATCH ALARM
+### EC2 ISOLATION LAMBDA DLQ CLOUDWATCH ALARM
 resource "aws_cloudwatch_metric_alarm" "ec2_isolation_dlq_visible_messages" {
   alarm_name          = "${var.name_prefix}-ec2-isolation-dlq-visible-messages"
   comparison_operator = "GreaterThanThreshold"
@@ -376,6 +376,15 @@ resource "aws_cloudwatch_event_target" "ec2_rollback" {
   target_id      = "Ec2RollbackLambda"
   arn            = aws_lambda_function.ec2_rollback.arn
 
+  dead_letter_config {
+    arn = aws_sqs_queue.ec2_rollback_dlq.arn
+  }
+
+  retry_policy {
+    maximum_event_age_in_seconds = 3600
+    maximum_retry_attempts       = 3
+  }
+
   depends_on = [
     aws_cloudwatch_event_rule.ec2_rollback
   ]
@@ -398,6 +407,101 @@ resource "aws_cloudwatch_log_group" "lambda_ec2_rollback" {
 
   tags = {
     Name        = "${var.name_prefix}-Lambda-EC2-Rollback-Logs"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+## EC2 ROLLBACK LAMBDA DLQ
+resource "aws_sqs_queue" "ec2_rollback_dlq" {
+  name              = "${var.name_prefix}-ec2-rollback-dlq"
+  kms_master_key_id = var.logs_cmk_arn
+
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name        = "${var.name_prefix}-Lambda-Rollback-DLQ"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+data "aws_iam_policy_document" "ec2_rollback_dlq_policy" {
+  statement {
+    sid    = "AllowEventBridgeToSendEC2RollbackFailures"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ec2_rollback_dlq.arn
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [
+        aws_cloudwatch_event_rule.ec2_rollback.arn
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowEC2RollbackRoleToSendFailures"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.lambda_ec2_rollback_role_arn
+      ]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ec2_rollback_dlq.arn
+    ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "ec2_rollback_dlq" {
+  queue_url = aws_sqs_queue.ec2_rollback_dlq.id
+  policy    = data.aws_iam_policy_document.ec2_rollback_dlq_policy.json
+}
+
+### EC2 ROLLBACK DLQ CLOUDWATCH ALARM
+resource "aws_cloudwatch_metric_alarm" "ec2_rollback_dlq_visible_messages" {
+  alarm_name          = "${var.name_prefix}-ec2-rollback-dlq-visible-messages"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.ec2_rollback_dlq.name
+  }
+
+  alarm_actions = [
+    var.secops_topic_arn
+  ]
+
+  tags = {
+    Name        = "${var.name_prefix}-EC2-Rollback-DLQ-Visible-Messages"
     Environment = var.environment
     Terraform   = "true"
   }

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -629,3 +629,98 @@ resource "aws_cloudwatch_log_group" "lambda_ip_enrichment" {
     Terraform   = "true"
   }
 }
+
+## IP ENRICHMENT LAMBDA DLQ
+resource "aws_sqs_queue" "ip_enrichment_dlq" {
+  name              = "${var.name_prefix}-ip-enrichment-dlq"
+  kms_master_key_id = var.logs_cmk_arn
+
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name        = "${var.name_prefix}-IP-Enrichment-DLQ"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+data "aws_iam_policy_document" "ip_enrichment_dlq_policy" {
+  statement {
+    sid    = "AllowEventBridgeToSendIPEnrichmentFailures"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ip_enrichment_dlq.arn
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [
+        aws_cloudwatch_event_rule.securityhub_high_critical.arn
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowIPEnrichmentRoleToSendFailures"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.lambda_ip_enrichment_role_arn
+      ]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ip_enrichment_dlq.arn
+    ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "ip_enrichment_dlq" {
+  queue_url = aws_sqs_queue.ip_enrichment_dlq.id
+  policy    = data.aws_iam_policy_document.ip_enrichment_dlq_policy.json
+}
+
+### EC2 ROLLBACK DLQ CLOUDWATCH ALARM
+resource "aws_cloudwatch_metric_alarm" "ip_enrichment_dlq_visible_messages" {
+  alarm_name          = "${var.name_prefix}-ip-enrichment-dlq-visible-messages"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.ip_enrichment_dlq.name
+  }
+
+  alarm_actions = [
+    var.secops_topic_arn
+  ]
+
+  tags = {
+    Name        = "${var.name_prefix}-IP-Enrichment-DLQ-Visible-Messages"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -604,6 +604,15 @@ resource "aws_cloudwatch_event_target" "ip_enrichment" {
   target_id = "IpEnrichment"
   arn       = aws_lambda_function.ip_enrichment.arn
 
+  dead_letter_config {
+    arn = aws_sqs_queue.ip_enrichment_dlq.arn
+  }
+
+  retry_policy {
+    maximum_event_age_in_seconds = 3600
+    maximum_retry_attempts       = 3
+  }
+
   depends_on = [
     aws_cloudwatch_event_rule.securityhub_high_critical
   ]

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_event_target" "ec2_isolation" {
 
   retry_policy {
     maximum_event_age_in_seconds = 3600
-    maximum_retry_attempts = 3
+    maximum_retry_attempts       = 3
   }
 
   depends_on = [
@@ -121,7 +121,7 @@ resource "aws_lambda_function_event_invoke_config" "ec2_isolation" {
   function_name = aws_lambda_function.ec2_isolation.function_name
 
   maximum_event_age_in_seconds = 3600
-  maximum_retry_attempts = 2
+  maximum_retry_attempts       = 2
 
   destination_config {
     on_failure {
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_log_group" "lambda_ec2_isolation" {
 
 ## EC2 ISOLATION DLQ
 resource "aws_sqs_queue" "ec2_isolation_dlq" {
-  name = "${var.name_prefix}-ec2-isolation-dlq"
+  name              = "${var.name_prefix}-ec2-isolation-dlq"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)
@@ -160,11 +160,11 @@ resource "aws_sqs_queue" "ec2_isolation_dlq" {
 
 data "aws_iam_policy_document" "ec2_isolation_dlq_policy" {
   statement {
-    sid = "AllowEventBridgeToSendEC2IsolationFailures"
+    sid    = "AllowEventBridgeToSendEC2IsolationFailures"
     effect = "Allow"
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["events.amazonaws.com"]
     }
 
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "ec2_isolation_dlq_policy" {
     ]
 
     condition {
-      test = "ArnEquals"
+      test     = "ArnEquals"
       variable = "aws:SourceArn"
       values = [
         aws_cloudwatch_event_rule.securityhub_ec2_high_critical.arn
@@ -186,7 +186,7 @@ data "aws_iam_policy_document" "ec2_isolation_dlq_policy" {
   }
 
   statement {
-    sid = "AllowEC2IsolationLambdaRoleToSendFailures"
+    sid    = "AllowEC2IsolationLambdaRoleToSendFailures"
     effect = "Allow"
 
     principals {
@@ -208,7 +208,7 @@ data "aws_iam_policy_document" "ec2_isolation_dlq_policy" {
 
 resource "aws_sqs_queue_policy" "ec2_isolation_dlq" {
   queue_url = aws_sqs_queue.ec2_isolation_dlq.id
-  policy = data.aws_iam_policy_document.ec2_isolation_dlq_policy.json
+  policy    = data.aws_iam_policy_document.ec2_isolation_dlq_policy.json
 }
 
 # EC2 ROLLBACK LAMBDA RESOURCES

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -62,8 +62,8 @@ resource "aws_security_group" "lambda_ec2_isolation_sg" {
   }
 }
 
-### EVENTBRIDGE RESOURCES
-#### EVENT RULE TO TRIGGER UPON HIGH/CRITICAL SECURITY HUB EC2 FINDINGS
+## EC2 ISOLATION EVENTBRIDGE RESOURCES
+### EVENT RULE TO TRIGGER UPON HIGH/CRITICAL SECURITY HUB EC2 FINDINGS
 resource "aws_cloudwatch_event_rule" "securityhub_ec2_high_critical" {
   name        = "${var.name_prefix}-securityhub-ec2-high-critical"
   description = "New High/Critical Security Hub EC2 findings"
@@ -87,7 +87,7 @@ resource "aws_cloudwatch_event_rule" "securityhub_ec2_high_critical" {
   })
 }
 
-#### EVENT TARGET FOR HIGH/CRITICAL SECURITY HUB EC2 FINDINGS EVENT RULE
+### EVENT TARGET FOR HIGH/CRITICAL SECURITY HUB EC2 FINDINGS EVENT RULE
 resource "aws_cloudwatch_event_target" "ec2_isolation" {
   rule      = aws_cloudwatch_event_rule.securityhub_ec2_high_critical.name
   target_id = "Ec2Isolation"
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_event_target" "ec2_isolation" {
   ]
 }
 
-#### PERMISSION TO ALLOW EVENTBRIDGE TO INVOKE EC2 ISOLATION LAMBDA
+### PERMISSION TO ALLOW EVENTBRIDGE TO INVOKE EC2 ISOLATION LAMBDA
 resource "aws_lambda_permission" "allow_eventbridge_ec2_isolation" {
   statement_id  = "AllowExecutionFromEventBridgeEc2Isolation"
   action        = "lambda:InvokeFunction"
@@ -107,7 +107,7 @@ resource "aws_lambda_permission" "allow_eventbridge_ec2_isolation" {
   source_arn    = aws_cloudwatch_event_rule.securityhub_ec2_high_critical.arn
 }
 
-### CLOUDWATCH LOG GROUP FOR EC2 ISOLATION LAMBDA
+## CLOUDWATCH LOG GROUP FOR EC2 ISOLATION LAMBDA
 resource "aws_cloudwatch_log_group" "lambda_ec2_isolation" {
   name              = "/aws/lambda/${var.name_prefix}-ec2-isolation"
   retention_in_days = var.cloudwatch_retention_days

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -93,6 +93,15 @@ resource "aws_cloudwatch_event_target" "ec2_isolation" {
   target_id = "Ec2Isolation"
   arn       = aws_lambda_function.ec2_isolation.arn
 
+  dead_letter_config {
+    arn = aws_sqs_queue.ec2_isolation_dlq.arn
+  }
+
+  retry_policy {
+    maximum_event_age_in_seconds = 3600
+    maximum_retry_attempts = 3
+  }
+
   depends_on = [
     aws_cloudwatch_event_rule.securityhub_ec2_high_critical
   ]

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -211,6 +211,33 @@ resource "aws_sqs_queue_policy" "ec2_isolation_dlq" {
   policy    = data.aws_iam_policy_document.ec2_isolation_dlq_policy.json
 }
 
+### EC2 ISOLATION CLOUDWATCH ALARM
+resource "aws_cloudwatch_metric_alarm" "ec2_isolation_dlq_visible_messages" {
+  alarm_name = "${var.name_prefix}-ec2-isolation-dlq-visible-messages"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods = 1
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  namespace = "AWS/SQS"
+  period = 300
+  statistic = "Maximum"
+  threshold = 0
+  treat_missing_data = "notBreaching"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.ec2_isolation_dlq.name
+  }
+
+  alarm_actions = [
+    var.secops_topic_arn
+  ]
+
+  tags = {
+    Name = "${var.name_prefix}-EC2-Isolation-DLQ-Visible-Messages"
+    Environment = var.environment
+    Terraform = "true"
+  }
+}
+
 # EC2 ROLLBACK LAMBDA RESOURCES
 ## PACKAGE EC2 ROLLBACK LAMBDA
 data "archive_file" "lambda_ec2_rollback" {

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -135,6 +135,59 @@ resource "aws_sqs_queue" "ec2_isolation_dlq" {
   }
 }
 
+data "aws_iam_policy_document" "ec2_isolation_dlq_policy" {
+  statement {
+    sid = "AllowEventBridgeToSendEC2IsolationFailures"
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ec2_isolation_dlq.arn
+    ]
+
+    condition {
+      test = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [
+        aws_cloudwatch_event_rule.securityhub_ec2_high_critical.arn
+      ]
+    }
+  }
+
+  statement {
+    sid = "AllowEC2IsolationLambdaRoleToSendFailures"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.lambda_ec2_isolation_role_arn
+      ]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.ec2_isolation_dlq.arn
+    ]
+  }
+}
+
+resource "aws_sqs_queue_policy" "ec2_isolation_dlq" {
+  queue_url = aws_sqs_queue.ec2_isolation_dlq.id
+  policy = data.aws_iam_policy_document.ec2_isolation_dlq_policy.json
+}
+
 # EC2 ROLLBACK LAMBDA RESOURCES
 ## PACKAGE EC2 ROLLBACK LAMBDA
 data "archive_file" "lambda_ec2_rollback" {

--- a/modules/automation/main.tf
+++ b/modules/automation/main.tf
@@ -120,6 +120,21 @@ resource "aws_cloudwatch_log_group" "lambda_ec2_isolation" {
   }
 }
 
+## EC2 ISOLATION DLQ
+resource "aws_sqs_queue" "ec2_isolation_dlq" {
+  name = "${var.name_prefix}-ec2-isolation-dlq"
+  kms_master_key_id = var.logs_cmk_arn
+
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name        = "${var.name_prefix}-Lambda-EC2-Isolation-DLQ"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
 # EC2 ROLLBACK LAMBDA RESOURCES
 ## PACKAGE EC2 ROLLBACK LAMBDA
 data "archive_file" "lambda_ec2_rollback" {

--- a/modules/automation/outputs.tf
+++ b/modules/automation/outputs.tf
@@ -19,7 +19,7 @@ output "lambda_ec2_rollback_sg_id" {
 }
 
 output "lambda_ec2_rollback_dlq_arn" {
-  value = aws_lambda_function.ec2_rollback.arn
+  value = aws_sqs_queue.ec2_rollback_dlq.arn
 }
 
 output "threat_intel_api_keys_arn" {

--- a/modules/automation/outputs.tf
+++ b/modules/automation/outputs.tf
@@ -18,6 +18,10 @@ output "lambda_ec2_rollback_sg_id" {
   value = aws_security_group.lambda_ec2_rollback_sg.id
 }
 
+output "lambda_ec2_rollback_dlq_arn" {
+  value = aws_lambda_function.ec2_rollback.arn
+}
+
 output "threat_intel_api_keys_arn" {
   value = aws_secretsmanager_secret.threat_intel_api_keys.arn
 }

--- a/modules/automation/outputs.tf
+++ b/modules/automation/outputs.tf
@@ -30,6 +30,10 @@ output "lambda_ip_enrichment_log_group_arn" {
   value = aws_cloudwatch_log_group.lambda_ip_enrichment.arn
 }
 
+output "lambda_ip_enrichment_dlq_arn" {
+  value = aws_sqs_queue.ip_enrichment_dlq.arn
+}
+
 output "securityhub_high_critical_rule_arn" {
   value = aws_cloudwatch_event_rule.securityhub_high_critical.arn
 }

--- a/modules/automation/outputs.tf
+++ b/modules/automation/outputs.tf
@@ -10,6 +10,10 @@ output "lambda_ec2_isolation_sg_id" {
   value = aws_security_group.lambda_ec2_isolation_sg.id
 }
 
+output "lambda_ec2_isolation_dlq_arn" {
+  value = aws_sqs_queue.ec2_isolation_dlq.arn
+}
+
 output "lambda_ec2_rollback_sg_id" {
   value = aws_security_group.lambda_ec2_rollback_sg.id
 }

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
   }
 
   statement {
-    sid = "SendEC2IsolationFailuresToDLQ"
+    sid    = "SendEC2IsolationFailuresToDLQ"
     effect = "Allow"
 
     actions = [

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -273,6 +273,19 @@ data "aws_iam_policy_document" "lambda_ip_enrichment" {
 
     resources = [var.secrets_manager_cmk_arn]
   }
+
+  statement {
+    sid    = "SendIPEnrichmentFailuresToDLQ"
+    effect = "Allow"
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      var.lambda_ip_enrichment_dlq_arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "lambda_ip_enrichment" {

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -76,6 +76,19 @@ data "aws_iam_policy_document" "lambda_ec2_isolation" {
 
     resources = [var.logs_cmk_arn]
   }
+
+  statement {
+    sid = "SendEC2IsolationFailuresToDLQ"
+    effect = "Allow"
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      var.lambda_ec2_isolation_dlq_arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "lambda_ec2_isolation" {

--- a/modules/iam/lambda.tf
+++ b/modules/iam/lambda.tf
@@ -167,6 +167,19 @@ data "aws_iam_policy_document" "lambda_ec2_rollback" {
 
     resources = [var.logs_cmk_arn]
   }
+
+  statement {
+    sid    = "SendEC2RollbackFailuresToDLQ"
+    effect = "Allow"
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      var.lambda_ec2_rollback_dlq_arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "lambda_ec2_rollback" {

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -61,3 +61,7 @@ variable "lambda_ip_enrichment_log_group_arn" {
 variable "break_glass_trusted_principal_arns" {
   type = list(string)
 }
+
+variable "lambda_ec2_isolation_dlq_arn" {
+  type = string
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -69,3 +69,7 @@ variable "lambda_ec2_isolation_dlq_arn" {
 variable "lambda_ec2_rollback_dlq_arn" {
   type = string
 }
+
+variable "lambda_ip_enrichment_dlq_arn" {
+  type = string
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -65,3 +65,7 @@ variable "break_glass_trusted_principal_arns" {
 variable "lambda_ec2_isolation_dlq_arn" {
   type = string
 }
+
+variable "lambda_ec2_rollback_dlq_arn" {
+  type = string
+}


### PR DESCRIPTION
Closes #488 - Create DLQ for EC2 Isolation Lambda func
Closes #493 - Create CloudWatch alarm that triggers when messages in the EC2-Isolation DLQ are > 0
Closes #489 - Create DLQ for EC2 Rollback Lambda func
Closes #494 - Create CloudWatch alarm that triggers when messages in the EC2-Rollback DLQ are > 0
Closes #490 - Create DLQ for IP Enrichment Lambda func
Closes #496 - Create CloudWatch alarm that triggers when messages in the IP-Enrichment DLQ are > 0