### PR TITLE
feat: create `security-notifications` SQS queue and DLQ and update validation scripts

### DIFF
--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -267,8 +267,8 @@ resource "aws_sns_topic_subscription" "secops" {
 
 resource "aws_sns_topic_subscription" "secops_notifications_sqs" {
   topic_arn = aws_sns_topic.secops.arn
-  protocol = "sqs"
-  endpoint = aws_sqs_queue.secops_notifications.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.secops_notifications.arn
 
   raw_message_delivery = true
 
@@ -336,17 +336,17 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
 
 #### CLOUDWATCH ALARM FOR SECOPS DLQ
 resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_messages" {
-  alarm_name = "${var.name_prefix}-security-notifications-dlq-visible-messages"
+  alarm_name        = "${var.name_prefix}-security-notifications-dlq-visible-messages"
   alarm_description = "Security Operations notifications DLQ has visible messages requiring review."
 
-  namespace = "AWS/SQS"
-  metric_name = "ApproximateNumberOfMessagesVisible"
-  statistic = "Maximum"
-  period = 300
-  evaluation_periods = 1
-  threshold = 0
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
   comparison_operator = "GreaterThanThreshold"
-  treat_missing_data = "notBreaching"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     QueueName = aws_sqs_queue.secops_notifications_dlq.name
@@ -357,9 +357,9 @@ resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_message
   ]
 
   tags = {
-    Name = "${var.name_prefix}-Security-Notifications-DLQ-Alarm"
+    Name        = "${var.name_prefix}-Security-Notifications-DLQ-Alarm"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 }
 
@@ -373,7 +373,7 @@ resource "aws_sqs_queue" "secops_notifications" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.secops_notifications_dlq.arn
-    maxReceiveCount = 5
+    maxReceiveCount     = 5
   })
 
   tags = {

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -116,7 +116,7 @@ resource "aws_sns_topic" "secops" {
 }
 
 ### SECOPS SNS TOPIC POLICY
-data "aws_iam_policy_document" "secops_notifications_sns" {
+data "aws_iam_policy_document" "security_notifications_sns" {
   statement {
     sid    = "EnableRootPermissions"
     effect = "Allow"
@@ -253,7 +253,7 @@ data "aws_iam_policy_document" "secops_notifications_sns" {
 
 resource "aws_sns_topic_policy" "secops" {
   arn    = aws_sns_topic.secops.arn
-  policy = data.aws_iam_policy_document.secops_notifications_sns.json
+  policy = data.aws_iam_policy_document.security_notifications_sns.json
 }
 
 ### SECOPS SNS SUBSCRIPTIONS
@@ -265,15 +265,15 @@ resource "aws_sns_topic_subscription" "secops" {
   endpoint  = each.value
 }
 
-resource "aws_sns_topic_subscription" "secops_notifications_sqs" {
+resource "aws_sns_topic_subscription" "security_notifications_sqs" {
   topic_arn = aws_sns_topic.secops.arn
   protocol  = "sqs"
-  endpoint  = aws_sqs_queue.secops_notifications.arn
+  endpoint  = aws_sqs_queue.security_notifications.arn
 
   raw_message_delivery = true
 
   depends_on = [
-    aws_sqs_queue.secops_notifications
+    aws_sqs_queue.security_notifications
   ]
 }
 
@@ -320,7 +320,7 @@ EOT
 
 ## SQS RESOURCES FOR SECURITY
 ### SECOPS NOTIFICATIONS SQS DLQ
-resource "aws_sqs_queue" "secops_notifications_dlq" {
+resource "aws_sqs_queue" "security_notifications_dlq" {
   name              = "${var.name_prefix}-security-notifications-dlq"
   kms_master_key_id = var.logs_cmk_arn
 
@@ -335,7 +335,7 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
 }
 
 #### CLOUDWATCH ALARM FOR SECOPS DLQ
-resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_messages" {
+resource "aws_cloudwatch_metric_alarm" "security_notifications_dlq_visible_messages" {
   alarm_name        = "${var.name_prefix}-security-notifications-dlq-visible-messages"
   alarm_description = "Security Operations notifications DLQ has visible messages requiring review."
 
@@ -349,7 +349,7 @@ resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_message
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    QueueName = aws_sqs_queue.secops_notifications_dlq.name
+    QueueName = aws_sqs_queue.security_notifications_dlq.name
   }
 
   alarm_actions = [
@@ -364,7 +364,7 @@ resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_message
 }
 
 ### SECOPS NOTIFICATIONS SQS QUEUE
-resource "aws_sqs_queue" "secops_notifications" {
+resource "aws_sqs_queue" "security_notifications" {
   name              = "${var.name_prefix}-security-notifications-queue"
   kms_master_key_id = var.logs_cmk_arn
 
@@ -372,7 +372,7 @@ resource "aws_sqs_queue" "secops_notifications" {
   message_retention_seconds = 1209600
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.secops_notifications_dlq.arn
+    deadLetterTargetArn = aws_sqs_queue.security_notifications_dlq.arn
     maxReceiveCount     = 5
   })
 
@@ -384,7 +384,7 @@ resource "aws_sqs_queue" "secops_notifications" {
 }
 
 #### QUEUE POLICY ALLOWING SECOPS SNS TOPIC TO PUBLISH
-data "aws_iam_policy_document" "secops_notifications_sqs" {
+data "aws_iam_policy_document" "security_notifications_sqs" {
   statement {
     sid    = "AllowSecurityNotificationsTopicToSendMessages"
     effect = "Allow"
@@ -399,14 +399,14 @@ data "aws_iam_policy_document" "secops_notifications_sqs" {
     ]
 
     resources = [
-      aws_sqs_queue.secops_notifications.arn
+      aws_sqs_queue.security_notifications.arn
     ]
   }
 }
 
-resource "aws_sqs_queue_policy" "secops_notifications" {
-  queue_url = aws_sqs_queue.secops_notifications.id
-  policy    = data.aws_iam_policy_document.secops_notifications_sqs.json
+resource "aws_sqs_queue_policy" "security_notifications" {
+  queue_url = aws_sqs_queue.security_notifications.id
+  policy    = data.aws_iam_policy_document.security_notifications_sqs.json
 }
 
 ### CLOUDWATCH EVENT RULES

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -309,7 +309,7 @@ EOT
 ## SQS RESOURCES FOR SECURITY
 ### SECOPS NOTIFICATIONS SQS DLQ
 resource "aws_sqs_queue" "secops_notifications_dlq" {
-  name              = "${var.name_prefix}-security-notifications-dlq"
+  name              = "${var.name_prefix}-secops-notifications-dlq"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -273,7 +273,7 @@ resource "aws_sns_topic_subscription" "security_notifications_sqs" {
   raw_message_delivery = true
 
   depends_on = [
-    aws_sqs_queue.security_notifications
+    aws_sqs_queue_policy.security_notifications
   ]
 }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -340,11 +340,11 @@ resource "aws_sqs_queue" "secops_notifications" {
 #### QUEUE POLICY ALLOWING SECOPS SNS TOPIC TO PUBLISH
 data "aws_iam_policy_document" "secops_notifications_queue_policy" {
   statement {
-    sid = "AllowSecurityNotificationsTopicToSendMessages"
+    sid    = "AllowSecurityNotificationsTopicToSendMessages"
     effect = "Allow"
 
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["sns.amazonaws.com"]
     }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -358,6 +358,11 @@ data "aws_iam_policy_document" "secops_notifications_sqs_policy" {
   }
 }
 
+resource "aws_sqs_queue_policy" "secops_notifications" {
+  queue_url = aws_sqs_queue.secops_notifications.id
+  policy = data.aws_iam_policy_document.secops_notifications_sqs_policy.json
+}
+
 ### CLOUDWATCH EVENT RULES
 
 ##########################################

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -306,6 +306,22 @@ EOT
   }
 }
 
+## SQS RESOURCES FOR SECURITY
+### SECOPS NOTIFICATIONS SQS DLQ
+resource "aws_sqs_queue" "secops_notifications_dlq" {
+  name = "${var.name_prefix}-security-notifications-dlq"
+  kms_master_key_id = var.logs_cmk_arn
+
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name = "${var.name_prefix}-Security-Notifications-DLQ"
+    Environment = var.environment
+    Terraform = "true"
+  }
+}
+
 ### CLOUDWATCH EVENT RULES
 
 ##########################################

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -338,7 +338,7 @@ resource "aws_sqs_queue" "secops_notifications" {
 }
 
 #### QUEUE POLICY ALLOWING SECOPS SNS TOPIC TO PUBLISH
-data "aws_iam_policy_document" "secops_notifications_sqs_policy" {
+data "aws_iam_policy_document" "secops_notifications_sqs" {
   statement {
     sid    = "AllowSecurityNotificationsTopicToSendMessages"
     effect = "Allow"
@@ -360,7 +360,7 @@ data "aws_iam_policy_document" "secops_notifications_sqs_policy" {
 
 resource "aws_sqs_queue_policy" "secops_notifications" {
   queue_url = aws_sqs_queue.secops_notifications.id
-  policy    = data.aws_iam_policy_document.secops_notifications_sqs_policy.json
+  policy    = data.aws_iam_policy_document.secops_notifications_sqs.json
 }
 
 ### CLOUDWATCH EVENT RULES

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -322,6 +322,21 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
   }
 }
 
+### SECOPS NOTIFICATIONS SQS QUEUE
+resource "aws_sqs_queue" "secops_notifications" {
+  name = "${var.name_prefix}-secops-notifications-queue"
+  kms_master_key_id = var.logs_cmk_arn
+
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name = "${var.name_prefix}-SecOps-Notifications-Queue"
+    Environment = var.environment
+    Terraform = "true"
+  }
+}
+
 ### CLOUDWATCH EVENT RULES
 
 ##########################################

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -116,7 +116,7 @@ resource "aws_sns_topic" "secops" {
 }
 
 ### SECOPS SNS TOPIC POLICY
-data "aws_iam_policy_document" "secops" {
+data "aws_iam_policy_document" "secops_notifications_sns" {
   statement {
     sid    = "EnableRootPermissions"
     effect = "Allow"
@@ -253,7 +253,7 @@ data "aws_iam_policy_document" "secops" {
 
 resource "aws_sns_topic_policy" "secops" {
   arn    = aws_sns_topic.secops.arn
-  policy = data.aws_iam_policy_document.secops.json
+  policy = data.aws_iam_policy_document.secops_notifications_sns.json
 }
 
 ### SECOPS SNS SUBSCRIPTION

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -401,6 +401,12 @@ data "aws_iam_policy_document" "security_notifications_sqs" {
     resources = [
       aws_sqs_queue.security_notifications.arn
     ]
+
+    condition {
+      test = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [aws_sns_topic.secops.arn]
+    }
   }
 }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -324,16 +324,16 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
 
 ### SECOPS NOTIFICATIONS SQS QUEUE
 resource "aws_sqs_queue" "secops_notifications" {
-  name = "${var.name_prefix}-secops-notifications-queue"
+  name              = "${var.name_prefix}-secops-notifications-queue"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)
   message_retention_seconds = 1209600
 
   tags = {
-    Name = "${var.name_prefix}-SecOps-Notifications-Queue"
+    Name        = "${var.name_prefix}-SecOps-Notifications-Queue"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -67,6 +67,9 @@ resource "aws_sqs_queue" "compliance" {
   name              = "${var.name_prefix}-compliance-queue"
   kms_master_key_id = var.logs_cmk_arn
 
+  # Maximum retention time for troubleshooting (14 days)
+  message_retention_seconds = 1209600
+
   tags = {
     Name        = "${var.name_prefix}-ComplianceQueue"
     Environment = var.environment

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -267,8 +267,8 @@ resource "aws_sns_topic_subscription" "secops" {
 
 resource "aws_sns_topic_subscription" "secops_notifications_sqs" {
   topic_arn = aws_sns_topic.secops.arn
-  protocol = "sqs"
-  endpoint = aws_sqs_queue.secops_notifications.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.secops_notifications.arn
 
   raw_message_delivery = true
 
@@ -336,17 +336,17 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
 
 #### CLOUDWATCH ALARM FOR SECOPS DLQ
 resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_messages" {
-  alarm_name = "${var.name_prefix}-security-notifications-dlq-visible-messages"
+  alarm_name        = "${var.name_prefix}-security-notifications-dlq-visible-messages"
   alarm_description = "Security Operations notifications DLQ has visible messages requiring review."
 
-  namespace = "AWS/SQS"
-  metric_name = "ApproximateNumberOfMessagesVisible"
-  statistic = "Maximum"
-  period = 300
-  evaluation_periods = 1
-  threshold = 0
+  namespace           = "AWS/SQS"
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
   comparison_operator = "GreaterThanThreshold"
-  treat_missing_data = "notBreaching"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     QueueName = aws_sqs_queue.secops_notifications_dlq.name
@@ -357,9 +357,9 @@ resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_message
   ]
 
   tags = {
-    Name = "${var.name_prefix}-SecOps-Notifications-DLQ-Alarm"
+    Name        = "${var.name_prefix}-SecOps-Notifications-DLQ-Alarm"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -403,9 +403,9 @@ data "aws_iam_policy_document" "security_notifications_sqs" {
     ]
 
     condition {
-      test = "ArnEquals"
+      test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values = [aws_sns_topic.secops.arn]
+      values   = [aws_sns_topic.secops.arn]
     }
   }
 }

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -316,7 +316,7 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
   message_retention_seconds = 1209600
 
   tags = {
-    Name = "${var.name_prefix}-Security-Notifications-DLQ"
+    Name = "${var.name_prefix}-SecOps-Notifications-DLQ"
     Environment = var.environment
     Terraform = "true"
   }

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -256,13 +256,25 @@ resource "aws_sns_topic_policy" "secops" {
   policy = data.aws_iam_policy_document.secops_notifications_sns.json
 }
 
-### SECOPS SNS SUBSCRIPTION
+### SECOPS SNS SUBSCRIPTIONS
 resource "aws_sns_topic_subscription" "secops" {
   for_each = toset(var.secops_emails)
 
   topic_arn = aws_sns_topic.secops.arn
   protocol  = "email"
   endpoint  = each.value
+}
+
+resource "aws_sns_topic_subscription" "secops_notifications_sqs" {
+  topic_arn = aws_sns_topic.secops.arn
+  protocol = "sqs"
+  endpoint = aws_sqs_queue.secops_notifications.arn
+
+  raw_message_delivery = true
+
+  depends_on = [
+    aws_sqs_queue.secops_notifications
+  ]
 }
 
 ### EVENTBRIDGE TARGET FOR SECURITY HUB HIGH + CRITICAL ALERTS (EVENT RULE LOCATED IN 'AUTOMATION' MODULE)

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -309,16 +309,16 @@ EOT
 ## SQS RESOURCES FOR SECURITY
 ### SECOPS NOTIFICATIONS SQS DLQ
 resource "aws_sqs_queue" "secops_notifications_dlq" {
-  name = "${var.name_prefix}-security-notifications-dlq"
+  name              = "${var.name_prefix}-security-notifications-dlq"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)
   message_retention_seconds = 1209600
 
   tags = {
-    Name = "${var.name_prefix}-SecOps-Notifications-DLQ"
+    Name        = "${var.name_prefix}-SecOps-Notifications-DLQ"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 }
 

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -360,7 +360,7 @@ data "aws_iam_policy_document" "secops_notifications_sqs_policy" {
 
 resource "aws_sqs_queue_policy" "secops_notifications" {
   queue_url = aws_sqs_queue.secops_notifications.id
-  policy = data.aws_iam_policy_document.secops_notifications_sqs_policy.json
+  policy    = data.aws_iam_policy_document.secops_notifications_sqs_policy.json
 }
 
 ### CLOUDWATCH EVENT RULES

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -371,6 +371,11 @@ resource "aws_sqs_queue" "secops_notifications" {
   # Maximum retention time for troubleshooting (14 days)
   message_retention_seconds = 1209600
 
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.secops_notifications_dlq.arn
+    maxReceiveCount = 5
+  })
+
   tags = {
     Name        = "${var.name_prefix}-Security-Notifications-Queue"
     Environment = var.environment

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -337,6 +337,27 @@ resource "aws_sqs_queue" "secops_notifications" {
   }
 }
 
+#### QUEUE POLICY ALLOWING SECOPS SNS TOPIC TO PUBLISH
+data "aws_iam_policy_document" "secops_notifications_queue_policy" {
+  statement {
+    sid = "AllowSecurityNotificationsTopicToSendMessages"
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    actions = [
+      "sqs:SendMessage"
+    ]
+
+    resources = [
+      aws_sqs_queue.secops_notifications.arn
+    ]
+  }
+}
+
 ### CLOUDWATCH EVENT RULES
 
 ##########################################

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -338,7 +338,7 @@ resource "aws_sqs_queue" "secops_notifications" {
 }
 
 #### QUEUE POLICY ALLOWING SECOPS SNS TOPIC TO PUBLISH
-data "aws_iam_policy_document" "secops_notifications_queue_policy" {
+data "aws_iam_policy_document" "secops_notifications_sqs_policy" {
   statement {
     sid    = "AllowSecurityNotificationsTopicToSendMessages"
     effect = "Allow"

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -267,8 +267,8 @@ resource "aws_sns_topic_subscription" "secops" {
 
 resource "aws_sns_topic_subscription" "secops_notifications_sqs" {
   topic_arn = aws_sns_topic.secops.arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.secops_notifications.arn
+  protocol = "sqs"
+  endpoint = aws_sqs_queue.secops_notifications.arn
 
   raw_message_delivery = true
 
@@ -321,14 +321,14 @@ EOT
 ## SQS RESOURCES FOR SECURITY
 ### SECOPS NOTIFICATIONS SQS DLQ
 resource "aws_sqs_queue" "secops_notifications_dlq" {
-  name              = "${var.name_prefix}-secops-notifications-dlq"
+  name              = "${var.name_prefix}-security-notifications-dlq"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)
   message_retention_seconds = 1209600
 
   tags = {
-    Name        = "${var.name_prefix}-SecOps-Notifications-DLQ"
+    Name        = "${var.name_prefix}-Security-Notifications-DLQ"
     Environment = var.environment
     Terraform   = "true"
   }
@@ -336,17 +336,17 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
 
 #### CLOUDWATCH ALARM FOR SECOPS DLQ
 resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_messages" {
-  alarm_name        = "${var.name_prefix}-security-notifications-dlq-visible-messages"
+  alarm_name = "${var.name_prefix}-security-notifications-dlq-visible-messages"
   alarm_description = "Security Operations notifications DLQ has visible messages requiring review."
 
-  namespace           = "AWS/SQS"
-  metric_name         = "ApproximateNumberOfMessagesVisible"
-  statistic           = "Maximum"
-  period              = 300
-  evaluation_periods  = 1
-  threshold           = 0
+  namespace = "AWS/SQS"
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  statistic = "Maximum"
+  period = 300
+  evaluation_periods = 1
+  threshold = 0
   comparison_operator = "GreaterThanThreshold"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     QueueName = aws_sqs_queue.secops_notifications_dlq.name
@@ -357,22 +357,22 @@ resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_message
   ]
 
   tags = {
-    Name        = "${var.name_prefix}-SecOps-Notifications-DLQ-Alarm"
+    Name = "${var.name_prefix}-Security-Notifications-DLQ-Alarm"
     Environment = var.environment
-    Terraform   = "true"
+    Terraform = "true"
   }
 }
 
 ### SECOPS NOTIFICATIONS SQS QUEUE
 resource "aws_sqs_queue" "secops_notifications" {
-  name              = "${var.name_prefix}-secops-notifications-queue"
+  name              = "${var.name_prefix}-security-notifications-queue"
   kms_master_key_id = var.logs_cmk_arn
 
   # Maximum retention time for troubleshooting (14 days)
   message_retention_seconds = 1209600
 
   tags = {
-    Name        = "${var.name_prefix}-SecOps-Notifications-Queue"
+    Name        = "${var.name_prefix}-Security-Notifications-Queue"
     Environment = var.environment
     Terraform   = "true"
   }

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -334,6 +334,35 @@ resource "aws_sqs_queue" "secops_notifications_dlq" {
   }
 }
 
+#### CLOUDWATCH ALARM FOR SECOPS DLQ
+resource "aws_cloudwatch_metric_alarm" "secops_notifications_dlq_visible_messages" {
+  alarm_name = "${var.name_prefix}-security-notifications-dlq-visible-messages"
+  alarm_description = "Security Operations notifications DLQ has visible messages requiring review."
+
+  namespace = "AWS/SQS"
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  statistic = "Maximum"
+  period = 300
+  evaluation_periods = 1
+  threshold = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data = "notBreaching"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.secops_notifications_dlq.name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.secops.arn
+  ]
+
+  tags = {
+    Name = "${var.name_prefix}-SecOps-Notifications-DLQ-Alarm"
+    Environment = var.environment
+    Terraform = "true"
+  }
+}
+
 ### SECOPS NOTIFICATIONS SQS QUEUE
 resource "aws_sqs_queue" "secops_notifications" {
   name              = "${var.name_prefix}-secops-notifications-queue"

--- a/scripts/validation/validate-sns.sh
+++ b/scripts/validation/validate-sns.sh
@@ -334,7 +334,7 @@ if [[ "$VALIDATED_TOPIC_COUNT" -eq 0 ]]; then
     TOTAL_SUBSCRIPTION_COUNT=$((TOTAL_SUBSCRIPTION_COUNT + subscription_count))
     TOTAL_PENDING_SUBSCRIPTION_COUNT=$((TOTAL_PENDING_SUBSCRIPTION_COUNT + pending_count))
 
-    SNS_SUMMARY_ROWS+=("${keyword}|${topic_arn}|${subscription_count}|${subscriptions_confirmed}|${subscriptions_pending}|${subscriptions_deleted}|${kms_key_id:-<none>}")
+    SNS_SUMMARY_ROWS+=("${keyword}|${topic_arn}|${subscription_count}|${subscriptions_confirmed}|${subscriptions_pending}|$([[ -n "$kms_key_id" ]] && echo "SSE-KMS" || echo "none")")
   done < <(echo "$MATCHING_TOPICS_JSON" | jq -r '.[].TopicArn')
 fi
 

--- a/scripts/validation/validate-sqs.sh
+++ b/scripts/validation/validate-sqs.sh
@@ -110,7 +110,7 @@ success "AWS credentials are valid"
 info "AWS account ID: $ACCOUNT_ID"
 info "AWS caller ARN: $CALLER_ARN"
 
-if [[ -n "$ACCOUNT_ID" ]]; then
+if [[ -n "$EXPECTED_ACCOUNT_ID" ]]; then
   if [[ "$ACCOUNT_ID" == "$EXPECTED_ACCOUNT_ID" ]]; then
     success "AWS account ID matches expected account: $EXPECTED_ACCOUNT_ID"
   else

--- a/scripts/validation/validate-sqs.sh
+++ b/scripts/validation/validate-sqs.sh
@@ -139,6 +139,11 @@ resource_name() {
 #   "eventbridge dlq|eventbridge-dlq|optional|none"
 EXPECTED_SQS_QUEUES=(
   "compliance|compliance-queue|required|sns:compliance-notifications"
+  "ec2-isolation|ec2-isolation-dlq|required|none"
+  "ec2-rollback|ec2-rollback-dlq|required|none"
+  "ip-enrichment|ip-enrichment-dlq|required|none"
+  "security-notifications|security-notifications-queue|required|sns:security-notifications"
+  "security-notifications-dlq|security-notifications-dlq|required|none"
 )
 
 QUEUE_SUMMARY_ROWS=()


### PR DESCRIPTION
Closes #491 - Create one security notification SQS queue subscribed to the security SNS topic
Closes #492 - Create DLQ for security notifications
Closes #498 - Update scripts/validation/validate-sqs.sh validation script to reference newly-created SQS queues