### PR TITLE
fix: Harden EC2 bootstrap patching and isolation dependencies to resolve EC2-related Security Hub findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## Unreleased
+
+This update hardens EC2 provisioning, boot-time vulnerability remediation, and
+automated isolation after validating the complete Amazon Inspector remediation
+path against fresh development deployments.
+
+### Added
+
+- Added strict first-boot Ubuntu patching that:
+  - rewrites Ubuntu APT sources to HTTPS;
+  - waits for package-manager locks and retries transient repository failures;
+  - forces IPv4 for APT repository access in the IPv4-only workload VPC;
+  - treats incomplete APT metadata refreshes as provisioning failures;
+  - performs a noninteractive `dist-upgrade` before installing required
+    bootstrap packages; and
+  - records relevant package versions and reboot-required state in the instance
+    bootstrap log.
+- Added `user_data_replace_on_change = true` so EC2 instances are replaced when
+  their bootstrap configuration changes.
+- Added a compute security-policy readiness object from the nested
+  `security_policy` module and passed it through `networking` into `compute`.
+- Added a `terraform_data` dependency bridge so EC2 instances wait for the
+  networking security-policy rules, including public HTTPS egress, before
+  launching and executing cloud-init.
+
+### Changed
+
+- Changed compute bootstrap handling to use a literal shell script instead of a
+  Terraform template when no Terraform interpolation is required.
+- Changed EC2 auto-isolation authorization to require
+  `IsolationAllowed=true` explicitly after trimming whitespace and normalizing
+  case.
+- Changed the isolation workflow to preserve the Terraform-managed
+  `IsolationAllowed` policy tag instead of changing it after isolation.
+- Changed EC2 lifecycle handling so Terraform ignores runtime quarantine
+  security-group replacement and Lambda-managed incident-response tags while
+  an instance is isolated.
+- Changed provisioning dependencies so the compute security group can still be
+  created early for nested networking security-policy rules, while only the EC2
+  instances wait for the completed security policy.
+
+### Fixed
+
+- Fixed a fresh-deployment race where EC2 cloud-init could execute before the
+  NAT route and compute HTTPS egress rule were ready, causing Ubuntu repository
+  connections to time out even though the completed development environment's
+  NAT path was healthy.
+- Fixed bootstrap behavior that allowed `apt-get update` repository failures to
+  fall back to stale package indexes, report `0 upgraded`, and incorrectly
+  complete successfully with vulnerable AMI package versions still installed.
+- Fixed Terraform template parsing failures caused by Bash/dpkg expressions
+  such as `${binary:Package}` being interpreted as Terraform interpolation.
+- Fixed EC2 isolation lifecycle settings that had been applied to the Lambda
+  resource instead of the EC2 instance resource.
+- Fixed the risk of a later Terraform apply restoring the normal compute
+  security group and removing active Lambda isolation state.
+
+### Security
+
+- Added deterministic boot-time installation of available Ubuntu security
+  updates before instances enter normal service.
+- Made isolation authorization fail closed unless the instance explicitly opts
+  in through `IsolationAllowed=true`.
+- Preserved policy ownership of `IsolationAllowed` in Terraform while retaining
+  Lambda-owned evidence tags for isolation status, finding ID, timestamp, and
+  original security groups.
+- Prevented normal Terraform reconciliation from silently reversing an active
+  quarantine action.
+
+### Notes
+
+- The existing weekly SSM Patch Manager maintenance window remains the ongoing
+  patching control; boot-time patching provides the initial remediation layer
+  for newly launched instances.
+- Development deployments continue to use the `nat_only` egress mode. Testing
+  confirmed that the NAT Gateway, Internet Gateway, route tables, security
+  groups, and NACLs were healthy after apply; the failure was caused by resource
+  readiness ordering during initial instance launch.
+
 ## v1.5.0
 
 This release completes the workload CI/CD integration (for now) by moving baseline and

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -53,6 +53,7 @@ module "compute" {
   environment = var.environment
 
   compute_private_subnet_ids_map = module.networking.compute_private_subnet_ids_map
+  compute_policy_rule_ids = module.networking.compute_policy_rule_ids
   instance_profile_name          = module.iam.instance_profile_name
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -53,7 +53,7 @@ module "compute" {
   environment = var.environment
 
   compute_private_subnet_ids_map = module.networking.compute_private_subnet_ids_map
-  compute_sg_rule_ids        = module.security_policy.compute_sg_rule_ids
+  compute_sg_rule_ids            = module.security_policy.compute_sg_rule_ids
   instance_profile_name          = module.iam.instance_profile_name
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -53,7 +53,7 @@ module "compute" {
   environment = var.environment
 
   compute_private_subnet_ids_map = module.networking.compute_private_subnet_ids_map
-  compute_policy_rule_ids        = module.security_policy.compute_policy_rule_ids
+  compute_sg_rule_ids        = module.security_policy.compute_sg_rule_ids
   instance_profile_name          = module.iam.instance_profile_name
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -53,7 +53,7 @@ module "compute" {
   environment = var.environment
 
   compute_private_subnet_ids_map = module.networking.compute_private_subnet_ids_map
-  compute_policy_rule_ids        = module.networking.compute_policy_rule_ids
+  compute_policy_rule_ids        = module.security_policy.compute_policy_rule_ids
   instance_profile_name          = module.iam.instance_profile_name
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -53,7 +53,7 @@ module "compute" {
   environment = var.environment
 
   compute_private_subnet_ids_map = module.networking.compute_private_subnet_ids_map
-  compute_policy_rule_ids = module.networking.compute_policy_rule_ids
+  compute_policy_rule_ids        = module.networking.compute_policy_rule_ids
   instance_profile_name          = module.iam.instance_profile_name
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -47,6 +47,11 @@ data "aws_ami" "ec2" {
   }
 }
 
+## Compute Security Group rule IDs that must exist before compute instances launch
+resource "terraform_data" "compute_security_policy_ready" {
+  input = var.compute_policy_rule_ids
+}
+
 ## EC2 INSTANCE
 resource "aws_instance" "ec2" {
   for_each               = var.compute_private_subnet_ids_map
@@ -83,6 +88,10 @@ resource "aws_instance" "ec2" {
       tags["OriginalSecurityGroups"],
     ]
   }
+
+  depends_on = [
+    terraform_data.compute_security_policy_ready
+  ]
 
   tags = {
     Name             = "${var.name_prefix}-EC2-${each.key}"

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -49,7 +49,7 @@ data "aws_ami" "ec2" {
 
 ## Compute Security Group rule IDs that must exist before compute instances launch
 resource "terraform_data" "compute_security_policy_ready" {
-  input = var.compute_policy_rule_ids
+  input = var.compute_sg_rule_ids
 }
 
 ## EC2 INSTANCE

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -48,9 +48,9 @@ variable "isolation_allowed" {
 variable "compute_policy_rule_ids" {
   description = "Security-policy rule IDs that must exist before EC2 instances launch"
   type = object({
-    endpoints_ingress_from_compute = string
-    compute_egress_to_endpoints = string
-    compute_egress_to_db = string
+    endpoints_ingress_from_compute    = string
+    compute_egress_to_endpoints       = string
+    compute_egress_to_db              = string
     compute_egress_to_internet_egress = optional(string)
   })
 }

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -44,3 +44,13 @@ variable "isolation_allowed" {
   type        = bool
   default     = false
 }
+
+variable "compute_policy_rule_ids" {
+  description = "Security-policy rule IDs that must exist before EC2 instances launch"
+  type = object({
+    endpoints_ingress_from_compute = string
+    compute_egress_to_endpoints = string
+    compute_egress_to_db = string
+    compute_egress_to_internet_egress = optional(string)
+  })
+}

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -45,8 +45,8 @@ variable "isolation_allowed" {
   default     = false
 }
 
-variable "compute_policy_rule_ids" {
-  description = "Security-policy rule IDs that must exist before EC2 instances launch"
+variable "compute_sg_rule_ids" {
+  description = "Security Group rule IDs that must exist before compute EC2 instances launch"
   type = object({
     endpoints_ingress_from_compute    = string
     compute_egress_to_endpoints       = string

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -86,5 +86,5 @@ output "endpoint_private_subnet_ids_list" {
 
 output "compute_policy_rule_ids" {
   description = "Compute security-policy rule IDs from the security_policy submodule"
-  value = module.security_policy.compute_policy_rule_ids
+  value       = module.security_policy.compute_policy_rule_ids
 }

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -83,8 +83,3 @@ output "endpoint_private_subnet_ids_list" {
   description = "list(string) of Endpoint Private Subnet IDs"
   value       = [for subnet in aws_subnet.endpoint_private : subnet.id]
 }
-
-output "compute_policy_rule_ids" {
-  description = "Compute security-policy rule IDs from the security_policy submodule"
-  value       = module.security_policy.compute_policy_rule_ids
-}

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -83,3 +83,8 @@ output "endpoint_private_subnet_ids_list" {
   description = "list(string) of Endpoint Private Subnet IDs"
   value       = [for subnet in aws_subnet.endpoint_private : subnet.id]
 }
+
+output "compute_policy_rule_ids" {
+  description = "Compute security-policy rule IDs from the security_policy submodule"
+  value = module.security_policy.compute_policy_rule_ids
+}

--- a/modules/networking/security_policy/outputs.tf
+++ b/modules/networking/security_policy/outputs.tf
@@ -1,0 +1,15 @@
+output "compute_policy_rule_ids" {
+  description = "Security Group Rule IDs that must exist before compute instances launch"
+
+  value =  {
+    endpoints_ingress_from_compute = aws_security_group_rule.endpoints_ingress_from_compute.id
+    compute_egress_to_endpoints    = aws_security_group_rule.compute_egress_to_endpoints.id
+
+    compute_egress_to_internet_https = try(
+      aws_security_group_rule.compute_egress_to_internet_https[0].id,
+      null
+    )
+
+    compute_egress_to_db = aws_security_group_rule.compute_egress_to_db.id
+  }
+}

--- a/modules/networking/security_policy/outputs.tf
+++ b/modules/networking/security_policy/outputs.tf
@@ -4,7 +4,7 @@ output "compute_policy_rule_ids" {
   value = {
     endpoints_ingress_from_compute = aws_security_group_rule.endpoints_ingress_from_compute.id
     compute_egress_to_endpoints    = aws_security_group_rule.compute_egress_to_endpoints.id
-    compute_egress_to_db = aws_security_group_rule.compute_egress_to_db.id
+    compute_egress_to_db           = aws_security_group_rule.compute_egress_to_db.id
 
     compute_egress_to_internet_https = try(
       aws_security_group_rule.compute_egress_to_internet_https[0].id,

--- a/modules/networking/security_policy/outputs.tf
+++ b/modules/networking/security_policy/outputs.tf
@@ -1,5 +1,5 @@
-output "compute_policy_rule_ids" {
-  description = "Security Group Rule IDs that must exist before compute instances launch"
+output "compute_sg_rule_ids" {
+  description = "Security Group rule IDs that must exist before compute EC2 instances launch"
 
   value = {
     endpoints_ingress_from_compute = aws_security_group_rule.endpoints_ingress_from_compute.id

--- a/modules/networking/security_policy/outputs.tf
+++ b/modules/networking/security_policy/outputs.tf
@@ -1,7 +1,7 @@
 output "compute_policy_rule_ids" {
   description = "Security Group Rule IDs that must exist before compute instances launch"
 
-  value =  {
+  value = {
     endpoints_ingress_from_compute = aws_security_group_rule.endpoints_ingress_from_compute.id
     compute_egress_to_endpoints    = aws_security_group_rule.compute_egress_to_endpoints.id
 

--- a/modules/networking/security_policy/outputs.tf
+++ b/modules/networking/security_policy/outputs.tf
@@ -4,12 +4,11 @@ output "compute_policy_rule_ids" {
   value = {
     endpoints_ingress_from_compute = aws_security_group_rule.endpoints_ingress_from_compute.id
     compute_egress_to_endpoints    = aws_security_group_rule.compute_egress_to_endpoints.id
+    compute_egress_to_db = aws_security_group_rule.compute_egress_to_db.id
 
     compute_egress_to_internet_https = try(
       aws_security_group_rule.compute_egress_to_internet_https[0].id,
       null
     )
-
-    compute_egress_to_db = aws_security_group_rule.compute_egress_to_db.id
   }
 }


### PR DESCRIPTION
Closes #617 - Fix patch management issue with the development deployment_profile