### PR TITLE
feat: create `bootstrap/security_operations/state` stack

### DIFF
--- a/bootstrap/control_plane/identity_center/main.tf
+++ b/bootstrap/control_plane/identity_center/main.tf
@@ -45,3 +45,20 @@ module "identity_center_staging" {
   logs_s3_readonly_policy_name = var.logs_s3_readonly_policy_name_staging
   customer_managed_policy_path = "/"
 }
+/*
+module "identity_center_secops" {
+  source = "../../../modules/identity_center"
+
+  account_id                   = var.account_id_secops
+  environment                  = "secops"
+  secops_operator_group_name   = "SecOps-Operator"
+  secops_event_bus_arn         = "arn:aws:events:${var.primary_region_staging}:${var.account_id_staging}:event-bus/secops-bus"
+  enable_secops_analyst        = var.enable_secops_analyst_staging
+  secops_analyst_group_name    = "SecOps-Analyst"
+  enable_secops_engineer       = var.enable_secops_engineer_staging
+  secops_engineer_group_name   = "SecOps-Engineer"
+  logs_cmk_decrypt_policy_name = var.logs_cmk_decrypt_policy_name_staging
+  logs_s3_readonly_policy_name = var.logs_s3_readonly_policy_name_staging
+  customer_managed_policy_path = "/"
+}
+*/

--- a/bootstrap/control_plane/identity_center/variables.tf
+++ b/bootstrap/control_plane/identity_center/variables.tf
@@ -51,7 +51,7 @@ variable "account_id_staging" {
 
 variable "account_id_secops" {
   description = "ID of the AWS account managing the 'security-operations' environment"
-  type = string
+  type        = string
 }
 
 variable "primary_region_dev" {

--- a/bootstrap/control_plane/identity_center/variables.tf
+++ b/bootstrap/control_plane/identity_center/variables.tf
@@ -48,12 +48,12 @@ variable "account_id_staging" {
   description = "ID of the AWS account managing the 'staging' environment"
   type        = string
 }
-
+/*
 variable "account_id_secops" {
   description = "ID of the AWS account managing the 'security-operations' environment"
   type        = string
 }
-
+*/
 variable "primary_region_dev" {
   description = "Primary region used by the 'dev' environment"
   type        = string

--- a/bootstrap/control_plane/identity_center/variables.tf
+++ b/bootstrap/control_plane/identity_center/variables.tf
@@ -49,6 +49,11 @@ variable "account_id_staging" {
   type        = string
 }
 
+variable "account_id_secops" {
+  description = "ID of the AWS account managing the 'security-operations' environment"
+  type = string
+}
+
 variable "primary_region_dev" {
   description = "Primary region used by the 'dev' environment"
   type        = string

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -25,7 +25,7 @@ resource "aws_organizations_organizational_unit" "prod" {
   parent_id = aws_organizations_organizational_unit.workloads.id
 }
 
-resource "aws_organizations_organizational_unit" "secops" {
-  name = "Security-Operations"
+resource "aws_organizations_organizational_unit" "security" {
+  name = "Security"
   parent_id = data.aws_organizations_organization.main.roots[0].id
 }

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -26,6 +26,6 @@ resource "aws_organizations_organizational_unit" "prod" {
 }
 
 resource "aws_organizations_organizational_unit" "security" {
-  name = "Security"
+  name      = "Security"
   parent_id = data.aws_organizations_organization.main.roots[0].id
 }

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -24,3 +24,8 @@ resource "aws_organizations_organizational_unit" "prod" {
   name      = "Prod"
   parent_id = aws_organizations_organizational_unit.workloads.id
 }
+
+resource "aws_organizations_organizational_unit" "secops" {
+  name = "Security-Operations"
+  parent_id = data.aws_organizations_organization.main.roots[0].id
+}

--- a/bootstrap/control_plane/state/outputs.tf
+++ b/bootstrap/control_plane/state/outputs.tf
@@ -1,4 +1,4 @@
-output "control_plane_account_id" {
+output "account_id" {
   description = "ID of the AWS account managing this environment"
   value       = data.aws_caller_identity.account_id.account_id
 }

--- a/bootstrap/security_operations/state/README.md
+++ b/bootstrap/security_operations/state/README.md
@@ -1,0 +1,237 @@
+# Terraform State Stack
+
+## Overview
+
+The `state` stack is responsible for provisioning the foundational backend infrastructure used by all other Terraform stacks in this repository.
+
+It deploys:
+- Centralized Terraform state storage (S3)
+- State locking (DynamoDB)
+- Encryption (KMS/CMK)
+
+This stack represents the root of trust for your entire infrastructure.
+
+---
+
+## ⚠️ CRITICAL WARNING ⚠️
+
+🚨 **THIS STACK MUST NEVER BE DESTROYED!** 🚨
+
+Destroying this stack will:
+- Delete, corrupt, or orphan Terraform state
+- Break all Terraform operations
+- Make safe infrastructure management impossible
+- Potentially require full environment rebuild
+
+This stack contains the backend for:
+- `bootstrap` stack (CI/CD execution plane)
+- `baseline` stack (infrastructure plane)
+- Any future environments (dev, staging, prod)
+
+This stack is the **foundation of all Terraform operations** in this environment.
+
+It must be deployed **first**, and only once per account.
+
+**There is NO safe recovery from accidental destruction.**
+
+Treat this stack as:
+- Permanent
+- Protected
+- Highly sensitive
+
+---
+
+## Architecture
+
+This stack exists in a separate control plane layer:
+
+- `state` stack ➔ `bootstrap` and `baseline` stacks
+  - `bootstrap` stack ➔ `github_oidc` module
+  - `baseline` stack ➔ All infrastructure (VPC, Lambda, S3, etc.)
+
+This separation ensures:
+- Terraform cannot destroy its own backend
+- CI/CD remains stable
+- Infrastructure lifecycle is safe
+
+---
+
+## State Management
+
+Unlike other stacks:
+
+- This stack initially uses local state
+- It bootstraps the remote backend used by all other stacks
+
+After deployment:
+- `bootstrap` and `baseline` use the S3 backend created here
+- This stack may optionally be migrated to remote state later
+
+---
+
+## Inputs
+
+| Name                     | Description                                      | Required |
+|--------------------------|--------------------------------------------------|----------|
+| `cloud_name`             | Name of env; used as prefix for resource naming  | Yes      |
+| `environment`            | Environment name (e.g., dev, prod)               | Yes      |
+| `account_id`             | AWS account ID                                   | Yes      |
+| `primary_region`         | AWS region                                       | Yes      |
+| `bucket_admin_principals`| ARNs allowed to modify bucket protections        | Yes      |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `tf_state_bucket_arn` | Name of the state S3 bucket |
+| `tf_state_bucket_name` | ARN of the state S3 bucket |
+| `tf_state_bucket_cmk_arn` | ARN of the KMS key |
+| `tf_state_lock_table_arn` | ARN of the DynamoDB state lock table |
+| `tf_state_lock_table_name` | Name of the DynamoDB state lock table |
+
+---
+
+## Files
+
+| File             | Purpose                                  |
+|------------------|------------------------------------------|
+| main.tf          | Calls the `state` module                   |
+| variables.tf     | Input variables                          |
+| outputs.tf       | Exposes backend resource values          |
+| README.md        | Documentation                            |
+
+---
+
+## Deployment and Integration with Other Stacks
+
+The following steps assume you are using the `bootstrap` stack, which enables OIDC between AWS and GitHub.
+
+If you are not using this feature, ignore any references to the `bootstrap` stack
+> For example, for:
+> ```bash
+> cd ../bootstrap
+> terraform init
+> cd ../baseline
+> terraform init
+> ```
+> Run this instead:
+> ```bash
+> cd ../baseline
+> terraform init
+> ```
+
+### Step 1: Navigate to the `state` stack and initialize it
+
+```bash
+cd state
+terraform init
+```
+> The `state` stack intentionally uses **local state** during initial deployment to bootstrap the remote backend
+
+### Step 2: Apply
+
+```bash
+terraform apply
+```
+
+This creates:
+- S3 state bucket
+- DynamoDB lock table
+- KMS key used by the state bucket
+
+### Step 3: Capture outputs for downstream stacks
+
+After apply, note the following outputs:
+- `tf_state_bucket_name`
+- `tf_state_bucket_arn`
+- `tf_state_bucket_cmk_arn`
+- `tf_state_lock_table_name`
+- `tf_state_lock_table_arn`
+
+### Step 4: Configure backend for `bootstrap` and `baseline` stacks
+
+Update `bootstrap/backend.tf`:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket  = "<tf_state_bucket_name>"
+    key     = "tf-state-bootstrap"
+    region  = "<primary_region>"
+    encrypt = true
+    dynamodb_table = "<tf_state_lock_table_name>"
+  }
+}
+```
+
+Update `baseline/backend.tf`:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket  = "<tf_state_bucket_name>"
+    key     = "tf-state-baseline"
+    region  = "<primary_region>"
+    encrypt = true
+    dynamodb_table = "<tf_state_lock_table_name>"
+  }
+}
+```
+> These `provider` / `terraform` blocks may already be configured correctly if using default variables
+
+Then initialize the `bootstrap` and `baseline` stacks:
+
+```bash
+cd ../bootstrap
+terraform init
+cd ../baseline
+terraform init
+```
+
+### Step 5: Proceed with Normal Deployment Flow
+
+At this point:
+- `bootstrap` stack can be deployed
+> Refer to `/bootstrap/README.md` file for instructions on configuring the `bootstrap` stack
+- `baseline` stack can be deployed
+> Refer to `/baseline/README.md` file for instructions on configuring the `baseline` stack
+- All stacks will use the centralized remote state created by this `state` stack
+
+---
+
+## Operational Guidelines
+
+### DO:
+- Protect this stack from deletion
+- Restrict access to trusted operators only
+- Back up local state if not migrated
+- Treat as critical infrastructure
+
+### DO NOT:
+- Run `terraform destroy` from within this stack
+- Modify backend resources outside Terraform
+- Share access broadly
+- Recreate or duplicate the state bucket
+- Recreate manually unless absolutely necessary
+
+---
+
+## Future Enhancements
+
+Optional improvements:
+- Remote backend for this stack (tf-state-state)
+- Cross-region replication for DR
+- Monitoring and alerting on state access
+- Access logging / CloudTrail data events
+
+---
+
+## Summary
+
+This stack is **NOT** just another Terraform deployment.
+
+It is the foundation of your entire platform.
+
+Handle it accordingly.

--- a/bootstrap/security_operations/state/backend.tf.migrated.example
+++ b/bootstrap/security_operations/state/backend.tf.migrated.example
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "tf-secure-baseline-security-operations-state"
+    key          = "control-plane/state.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/bootstrap/security_operations/state/backend.tf.migrated.example
+++ b/bootstrap/security_operations/state/backend.tf.migrated.example
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket       = "tf-secure-baseline-security-operations-state"
-    key          = "control-plane/state.tfstate"
+    key          = "security-operations/state.tfstate"
     region       = "us-east-1"
     encrypt      = true
     use_lockfile = true

--- a/bootstrap/security_operations/state/main.tf
+++ b/bootstrap/security_operations/state/main.tf
@@ -1,0 +1,20 @@
+#################################
+# STATE STACK
+#################################
+
+locals {
+  name_prefix = "${var.cloud_name}-${var.environment}"
+}
+
+data "aws_caller_identity" "account_id" {}
+
+module "state" {
+  source = "../../../modules/state"
+
+  name_prefix             = local.name_prefix
+  cloud_name              = var.cloud_name
+  environment             = var.environment
+  primary_region          = var.primary_region
+  account_id              = data.aws_caller_identity.account_id.account_id
+  bucket_admin_principals = var.bucket_admin_principals
+}

--- a/bootstrap/security_operations/state/outputs.tf
+++ b/bootstrap/security_operations/state/outputs.tf
@@ -1,0 +1,19 @@
+output "control_plane_account_id" {
+  description = "ID of the AWS account managing this environment"
+  value       = data.aws_caller_identity.account_id.account_id
+}
+
+output "tf_state_bucket_arn" {
+  description = "ARN of the S3 bucket where the Terraform state is stored"
+  value       = module.state.tf_state_bucket_arn
+}
+
+output "tf_state_bucket_name" {
+  description = "Name of the S3 bucket where the Terraform state is stored"
+  value       = module.state.tf_state_bucket_name
+}
+
+output "tf_state_bucket_cmk_arn" {
+  description = "ARN of the KMS CMK used to encrypt the Terraform State bucket"
+  value       = module.state.tf_state_bucket_cmk_arn
+}

--- a/bootstrap/security_operations/state/outputs.tf
+++ b/bootstrap/security_operations/state/outputs.tf
@@ -1,4 +1,4 @@
-output "control_plane_account_id" {
+output "account_id" {
   description = "ID of the AWS account managing this environment"
   value       = data.aws_caller_identity.account_id.account_id
 }

--- a/bootstrap/security_operations/state/providers.tf
+++ b/bootstrap/security_operations/state/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=1.13.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.40.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.primary_region
+}

--- a/bootstrap/security_operations/state/terraform.tfvars.example
+++ b/bootstrap/security_operations/state/terraform.tfvars.example
@@ -1,0 +1,8 @@
+cloud_name     = "tf-secure-baseline"
+environment    = "control-plane"
+primary_region = "us-east-1"
+
+bucket_admin_principals = [
+  "arn:aws:iam::123456789012:root",
+  "arn:aws:iam::123456789012:role/tf-secure-baseline-control-plane-github-apply-role"
+]

--- a/bootstrap/security_operations/state/terraform.tfvars.example
+++ b/bootstrap/security_operations/state/terraform.tfvars.example
@@ -1,8 +1,8 @@
 cloud_name     = "tf-secure-baseline"
-environment    = "control-plane"
+environment    = "security-operations"
 primary_region = "us-east-1"
 
 bucket_admin_principals = [
   "arn:aws:iam::123456789012:root",
-  "arn:aws:iam::123456789012:role/tf-secure-baseline-control-plane-github-apply-role"
+  "arn:aws:iam::123456789012:role/tf-secure-baseline-security-operations-github-apply-role"
 ]

--- a/bootstrap/security_operations/state/variables.tf
+++ b/bootstrap/security_operations/state/variables.tf
@@ -1,0 +1,23 @@
+variable "cloud_name" {
+  description = "The name of this cloud environment"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "primary_region" {
+  type = string
+}
+
+variable "bucket_admin_principals" {
+  description = "IAM principal ARNs allowed to administer protected S3 bucket settings."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.bucket_admin_principals) > 0
+    error_message = "bucket_admin_principals must contain at least one IAM principal ARN."
+  }
+}

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -14,6 +14,7 @@ Supported command targets and directories:
 | `staging` | `bootstrap/staging/state` |
 | `prod` | `bootstrap/prod/state` |
 | `control-plane` | `bootstrap/control_plane/state` |
+| `security-operations` | `bootstrap/security_operations/state` |
 
 Example:
 

--- a/scripts/bootstrap/migrate-state-stack.sh
+++ b/scripts/bootstrap/migrate-state-stack.sh
@@ -11,7 +11,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 usage() {
   cat <<'USAGE'
 Usage:
-  migrate-state-stack.sh <dev|staging|prod|control-plane> [--verify-only]
+  migrate-state-stack.sh <dev|staging|prod|control-plane|security-operations> [--verify-only]
 
 Options:
   --verify-only    Verify an already-migrated state stack.
@@ -90,6 +90,10 @@ case "$TARGET" in
   control-plane|control_plane)
     STACK_PATH_COMPONENT="control_plane"
     DISPLAY_TARGET="control-plane"
+    ;;
+  security-operations|security_operations)
+    STACK_PATH_COMPONENT="security_operations"
+    DISPLAY_TARGET="security-operations"
     ;;
   *)
     usage

--- a/scripts/validation/validate-control-plane.sh
+++ b/scripts/validation/validate-control-plane.sh
@@ -857,12 +857,12 @@ info "Organizations outputs size: $(echo "$ORGANIZATIONS_OUTPUTS_JSON" | jq 'len
 
 section "Checking state stack Terraform outputs"
 
-require_terraform_output "$STATE_OUTPUTS_JSON" control_plane_account_id "state"
+require_terraform_output "$STATE_OUTPUTS_JSON" account_id "state"
 require_terraform_output "$STATE_OUTPUTS_JSON" tf_state_bucket_name "state"
 require_terraform_output "$STATE_OUTPUTS_JSON" tf_state_bucket_arn "state"
 require_terraform_output "$STATE_OUTPUTS_JSON" tf_state_bucket_cmk_arn "state"
 
-STATE_ACCOUNT_ID="$(get_terraform_output_value "$STATE_OUTPUTS_JSON" control_plane_account_id)"
+STATE_ACCOUNT_ID="$(get_terraform_output_value "$STATE_OUTPUTS_JSON" account_id)"
 STATE_BUCKET_NAME="$(get_terraform_output_value "$STATE_OUTPUTS_JSON" tf_state_bucket_name)"
 STATE_BUCKET_ARN="$(get_terraform_output_value "$STATE_OUTPUTS_JSON" tf_state_bucket_arn)"
 STATE_CMK_ARN="$(get_terraform_output_value "$STATE_OUTPUTS_JSON" tf_state_bucket_cmk_arn)"


### PR DESCRIPTION
Closes #629 - Create new security_operations bootstrap stack and build its state substack
Closes #627 - Create a new AWS account and name it security-operations
Closes #626 - Consider centralizing Security Hub and Guard Duty to the control-plane account
Closes #631 - Update scripts/bootstrap/migrate-state-stack.sh to accept security-operations as an argument