### PR TITLE
feat: Create `security_operations/security_services` substack with Security Hub configured

### DIFF
--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -49,7 +49,7 @@ locals {
 
 check "security_operations_account" {
   assert {
-    condition = length(local.security_operations_accounts) == 1
+    condition     = length(local.security_operations_accounts) == 1
     error_message = "Exactly one AWS Organizations account name '${var.security_operations_account_name}' must exist."
   }
 }

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -63,7 +63,7 @@ resource "aws_organizations_aws_service_access" "securityhub" {
 resource "aws_securityhub_organization_admin_account" "security_operations" {
   count = var.enable_securityhub_delegated_administrator ? 1 : 0
 
-  admin_account_id = var.security_operations_account_id
+  admin_account_id = local.security_operations_account_id
 
   depends_on = [
     aws_organizations_aws_service_access.securityhub

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -34,6 +34,19 @@ resource "aws_organizations_organizational_unit" "security" {
 # SECURITY HUB ORGANIZATION INTEGRATION
 ##########################################
 
+locals {
+  security_operations_accounts = [
+    for account in data.aws_organizations_organization.main.accounts :
+    account
+    if account.name == var.security_operations_account_name
+  ]
+
+  security_operations_account_id = try(
+    one(local.security_operations_accounts).id,
+    null
+  )
+}
+
 resource "aws_organizations_aws_service_access" "securityhub" {
   count = var.enable_securityhub_delegated_administrator ? 1 : 0
 

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -49,7 +49,10 @@ locals {
 
 check "security_operations_account" {
   assert {
-    condition     = length(local.security_operations_accounts) == 1
+    condition     = (
+      !var.enable_securityhub_delegated_administrator ||
+      length(local.security_operations_accounts) == 1
+    )
     error_message = "Exactly one AWS Organizations account name '${var.security_operations_account_name}' must exist."
   }
 }

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -29,3 +29,23 @@ resource "aws_organizations_organizational_unit" "security" {
   name      = "Security"
   parent_id = data.aws_organizations_organization.main.roots[0].id
 }
+
+##########################################
+# SECURITY HUB ORGANIZATION INTEGRATION
+##########################################
+
+resource "aws_organizations_aws_service_access" "securityhub" {
+  count = var.enable_securityhub_delegated_administrator ? 1 : 0
+
+  service_principal = "securityhub.amazonaws.com"
+}
+
+resource "aws_securityhub_organization_admin_account" "security_operations" {
+  count = var.enable_securityhub_delegated_administrator ? 1 : 0
+
+  admin_account_id = var.security_operations_account_id
+
+  depends_on = [
+    aws_organizations_aws_service_access.securityhub
+  ]
+}

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -49,7 +49,7 @@ locals {
 
 check "security_operations_account" {
   assert {
-    condition     = (
+    condition = (
       !var.enable_securityhub_delegated_administrator ||
       length(local.security_operations_accounts) == 1
     )

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -47,6 +47,13 @@ locals {
   )
 }
 
+check "security_operations_account" {
+  assert {
+    condition = length(local.security_operations_accounts) == 1
+    error_message = "Exactly one AWS Organizations account name '${var.security_operations_account_name}' must exist."
+  }
+}
+
 resource "aws_organizations_aws_service_access" "securityhub" {
   count = var.enable_securityhub_delegated_administrator ? 1 : 0
 

--- a/bootstrap/control_plane/organizations/outputs.tf
+++ b/bootstrap/control_plane/organizations/outputs.tf
@@ -7,6 +7,6 @@ output "securityhub_delegated_administrator_account_id" {
 }
 
 output "securityhub_trusted_access_enabled" {
-  description = "Whether trusted access for Security Hub is managed by this stack"
-  value       = var.enable_securityhub_delegated_administrator
+  description = "Whether this stack manages trusted access for Security Hub"
+  value       = length(aws_organizations_aws_service_access.securityhub) == 1
 }

--- a/bootstrap/control_plane/organizations/outputs.tf
+++ b/bootstrap/control_plane/organizations/outputs.tf
@@ -8,5 +8,5 @@ output "securityhub_delegated_administrator_account_id" {
 
 output "securityhub_trusted_access_enabled" {
   description = "Whether trusted access for Security Hub is managed by this stack"
-  value = var.enable_securityhub_delegated_administrator
+  value       = var.enable_securityhub_delegated_administrator
 }

--- a/bootstrap/control_plane/organizations/outputs.tf
+++ b/bootstrap/control_plane/organizations/outputs.tf
@@ -1,0 +1,12 @@
+output "securityhub_delegated_administrator_account_id" {
+  description = "Account ID designated as the Security Hub administrator"
+  value = try(
+    aws_securityhub_organization_admin_account.security_operations[0].admin_account_id,
+    null
+  )
+}
+
+output "securityhub_trusted_access_enabled" {
+  description = "Whether trusted access for Security Hub is managed by this stack"
+  value = var.enable_securityhub_delegated_administrator
+}

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -1,0 +1,9 @@
+variable "security_operations_account_id" {
+  description = "AWS account ID designated as the centralized security-services administrator"
+  type = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.security_operations_account_id))
+    error_message = "security_operations_account_id must be a 12-digit AWS account ID."
+  }
+}

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -1,6 +1,6 @@
 variable "security_operations_account_id" {
   description = "AWS account ID designated as the centralized security-services administrator"
-  type = string
+  type        = string
 
   validation {
     condition     = can(regex("^[0-9]{12}$", var.security_operations_account_id))

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -1,5 +1,5 @@
 variable "enable_securityhub_delegated_administrator" {
-  description = "Enable Security Hub trusted accerss and designate the security-operations account as administrator"
+  description = "Enable Security Hub trusted access and designate the security-operations account as administrator"
   type        = bool
   default     = false
 }

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -10,6 +10,6 @@ variable "security_operations_account_id" {
 
 variable "enable_securityhub_delegated_administrator" {
   description = "Enable Security Hub trusted accerss and designate the security-operations account as administrator"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -7,3 +7,9 @@ variable "security_operations_account_id" {
     error_message = "security_operations_account_id must be a 12-digit AWS account ID."
   }
 }
+
+variable "enable_securityhub_delegated_administrator" {
+  description = "Enable Security Hub trusted accerss and designate the security-operations account as administrator"
+  type = bool
+  default = false
+}

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -16,6 +16,6 @@ variable "enable_securityhub_delegated_administrator" {
 
 variable "security_operations_account_name" {
   description = "Name of the AWS Organizations account used for centralized security operations"
-  type = string
-  default = "security-operations"
+  type        = string
+  default     = "security-operations"
 }

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -1,13 +1,3 @@
-variable "security_operations_account_id" {
-  description = "AWS account ID designated as the centralized security-services administrator"
-  type        = string
-
-  validation {
-    condition     = can(regex("^[0-9]{12}$", var.security_operations_account_id))
-    error_message = "security_operations_account_id must be a 12-digit AWS account ID."
-  }
-}
-
 variable "enable_securityhub_delegated_administrator" {
   description = "Enable Security Hub trusted accerss and designate the security-operations account as administrator"
   type        = bool

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -13,3 +13,9 @@ variable "enable_securityhub_delegated_administrator" {
   type        = bool
   default     = false
 }
+
+variable "security_operations_account_name" {
+  description = "Name of the AWS Organizations account used for centralized security operations"
+  type = string
+  default = "security-operations"
+}

--- a/bootstrap/security_operations/security_services/backend.tf
+++ b/bootstrap/security_operations/security_services/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "tf-secure-baseline-security-operations-state"
+    key          = "security-operation/security-services.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -1,3 +1,12 @@
 locals {
   name_prefix = "${var.cloud_name}-${var.environment}"
 }
+
+data "aws_caller_identity" "current" {}
+
+check "target_account" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == var.account_id
+    error_message = "The active AWS credentials do not belong to the configured security-operations account."
+  }
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -17,7 +17,7 @@ check "target_account" {
 
 resource "aws_securityhub_account" "main" {
   enable_default_standards = false
-  auto_enable_controls = false
+  auto_enable_controls     = false
 }
 
 ##########################################

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -17,6 +17,7 @@ check "target_account" {
 
 resource "aws_securityhub_account" "main" {
   enable_default_standards = false
+  auto_enable_controls = false
 }
 
 ##########################################

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -10,3 +10,11 @@ check "target_account" {
     error_message = "The active AWS credentials do not belong to the configured security-operations account."
   }
 }
+
+##########################################
+# SECURITY HUB ADMINISTRATOR ACCOUNT
+##########################################
+
+resource "aws_securityhub_account" "main" {
+  enable_default_standards = false
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -18,3 +18,15 @@ check "target_account" {
 resource "aws_securityhub_account" "main" {
   enable_default_standards = false
 }
+
+##########################################
+# SECURITY HUB HOME REGION
+##########################################
+
+resource "aws_securityhub_finding_aggregator" "main" {
+  linking_mode = "NO_REGIONS"
+
+  depends_on = [
+    aws_securityhub_account.main
+  ]
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -1,0 +1,3 @@
+locals {
+  name_prefix = "${var.cloud_name}-${var.environment}"
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -30,3 +30,22 @@ resource "aws_securityhub_finding_aggregator" "main" {
     aws_securityhub_account.main
   ]
 }
+
+##########################################
+# CENTRAL ORGANIZATION CONFIGURATION
+##########################################
+
+resource "aws_securityhub_organization_configuration" "main" {
+  count = var.enable_securityhub_organization_configuration ? 1 : 0
+
+  auto_enable           = false
+  auto_enable_standards = "NONE"
+
+  organization_configuration {
+    configuration_type = "CENTRAL"
+  }
+
+  depends_on = [
+    aws_securityhub_finding_aggregator.main
+  ]
+}

--- a/bootstrap/security_operations/security_services/outputs.tf
+++ b/bootstrap/security_operations/security_services/outputs.tf
@@ -1,0 +1,19 @@
+output "security_operations_account_id" {
+  description = "AWS account ID managing centralized security services"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "securityhub_home_region" {
+  description = "Security Hub home Region"
+  value       = var.primary_region
+}
+
+output "securityhub_finding_aggregator_arn" {
+  description = "ARN of the Security Hub finding aggregator"
+  value       = aws_securityhub_finding_aggregator.this.arn
+}
+
+output "securityhub_central_configuration_enabled" {
+  description = "Whether Security Hub central organization configuration is enabled"
+  value       = var.enable_securityhub_organization_configuration
+}

--- a/bootstrap/security_operations/security_services/outputs.tf
+++ b/bootstrap/security_operations/security_services/outputs.tf
@@ -10,7 +10,7 @@ output "securityhub_home_region" {
 
 output "securityhub_finding_aggregator_arn" {
   description = "ARN of the Security Hub finding aggregator"
-  value       = aws_securityhub_finding_aggregator.this.arn
+  value       = aws_securityhub_finding_aggregator.main.arn
 }
 
 output "securityhub_central_configuration_enabled" {

--- a/bootstrap/security_operations/security_services/providers.tf
+++ b/bootstrap/security_operations/security_services/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">=1.13.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.40.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.primary_region
+}

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -1,13 +1,35 @@
 variable "cloud_name" {
-  description = "The name of this cloud environment"
+  description = "Name of the cloud platform"
   type        = string
 }
 
 variable "environment" {
-  description = "Environment name"
+  description = "Name of the specialized security account environment"
   type        = string
+
+  validation {
+    condition     = var.environment == "security-operations"
+    error_message = "environment must be security-operations."
+  }
 }
 
 variable "primary_region" {
-  type = string
+  description = "Primary and Security Hub home Region"
+  type        = string
+}
+
+variable "account_id" {
+  description = "AWS account ID of the security-operations account"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "enable_securityhub_organization_configuration" {
+  description = "Enable Security Hub central organization configuration after delegated administration is configured"
+  type        = bool
+  default     = false
 }

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -1,0 +1,13 @@
+variable "cloud_name" {
+  description = "The name of this cloud environment"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "primary_region" {
+  type = string
+}


### PR DESCRIPTION
Closes #636 - Create security_operations/security_services substack, consisting of security hub
Closes #638 - Register the security_operations account as the security hub delegated administrator in Organizations