### PR TITLE
feat: configure centralized Security Hub CSPM for the `prod` workload environment

### DIFF
--- a/bootstrap/security_operations/security_services/outputs.tf
+++ b/bootstrap/security_operations/security_services/outputs.tf
@@ -18,7 +18,7 @@ output "securityhub_central_configuration_enabled" {
   value       = var.enable_securityhub_organization_configuration
 }
 
-output "securityhub_cspm_configuraiton_policy_ids" {
+output "securityhub_cspm_configuration_policy_ids" {
   description = "Security Hub CSPM configuration policy IDs by AWS Organizations account name"
 
   value = {

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -21,4 +21,5 @@ module "baseline" {
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
+  manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -21,5 +21,5 @@ module "baseline" {
   break_glass_trusted_principal_arns = var.break_glass_trusted_principal_arns
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
-  manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
+  manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -152,3 +152,9 @@ variable "isolation_allowed" {
   type        = bool
   default     = false
 }
+
+variable "manage_securityhub_cspm_locally" {
+  description = "Whether this workload account manages its own Security Hub CSPM enablement and standards. Set to false when CSPM is centrally managed from the security-operations account."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Closes #645 - Configure centralized Security Hub CSPM for the prod workload environment