### PR TITLE
feat: Centralize `GuardDuty` for all workload accounts

### DIFF
--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -126,7 +126,7 @@ module "security" {
   centralized_logs_bucket_name = module.storage.centralized_logs_bucket_name
 
   manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
-  manage_guardduty_locally = var.manage_guardduty_locally
+  manage_guardduty_locally        = var.manage_guardduty_locally
   guardduty_features              = var.guardduty_features
   enable_rules                    = local.effective_enable_rules
   inspector_enabled               = local.effective_inspector_enabled

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -126,6 +126,7 @@ module "security" {
   centralized_logs_bucket_name = module.storage.centralized_logs_bucket_name
 
   manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
+  manage_guardduty_locally = var.manage_guardduty_locally
   guardduty_features              = var.guardduty_features
   enable_rules                    = local.effective_enable_rules
   inspector_enabled               = local.effective_inspector_enabled

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -279,11 +279,11 @@ variable "isolation_allowed" {
 variable "manage_securityhub_cspm_locally" {
   description = "Whether this workload account manages its own Security Hub CSPM enablement and standards. Set to false when CSPM is centrally managed from the security-operations account."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -131,8 +131,8 @@ variable "secops_emails" {
 }
 
 variable "guardduty_features" {
-  description = "List of GuardDuty features that dictate what data GuardDuty analyzes"
-  type        = list(string)
+  description = "GuardDuty protection plans centrally enabled across the AWS organization."
+  type        = set(string)
   default = [
     "S3_DATA_EVENTS",
     "EBS_MALWARE_PROTECTION",

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -132,7 +132,7 @@ variable "secops_emails" {
 
 variable "guardduty_features" {
   description = "GuardDuty protection plans centrally enabled across the AWS organization."
-  type        = set(string)
+  type        = list(string)
   default = [
     "S3_DATA_EVENTS",
     "EBS_MALWARE_PROTECTION",

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -281,3 +281,9 @@ variable "manage_securityhub_cspm_locally" {
   type        = bool
   default     = false
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type        = bool
+  default     = false
+}

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -131,7 +131,7 @@ variable "secops_emails" {
 }
 
 variable "guardduty_features" {
-  description = "GuardDuty protection plans centrally enabled across the AWS organization."
+  description = "List of GuardDuty features that dictate what data GuardDuty analyzes"
   type        = list(string)
   default = [
     "S3_DATA_EVENTS",

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -29,7 +29,7 @@ check "guardduty_detector_enabled" {
 ##########################################
 
 resource "aws_guardduty_organization_configuration" "main" {
-  region = var.primary_region
+  region      = var.primary_region
   detector_id = data.aws_guardduty_detector.main.id
 
   auto_enable_organization_members = "ALL"

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -17,6 +17,13 @@ data "aws_guardduty_detector" "main" {
   region = var.primary_region
 }
 
+check "guardduty_detector_enabled" {
+  assert {
+    condition     = data.aws_guardduty_detector.main.status == "ENABLED"
+    error_message = "The security-operations GuardDuty detector must be enabled."
+  }
+}
+
 ##########################################
 # GUARDDUTY ORGANIZATION CONFIGURATION
 ##########################################

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -13,14 +13,17 @@ check "target_account" {
 # GUARDDUTY ADMINISTRATOR DETECTOR
 ##########################################
 
-data "aws_guardduty_detector" "security_operations" {}
+data "aws_guardduty_detector" "main" {
+  region = var.primary_region
+}
 
 ##########################################
 # GUARDDUTY ORGANIZATION CONFIGURATION
 ##########################################
 
 resource "aws_guardduty_organization_configuration" "main" {
-  detector_id = data.aws_guardduty_detector.security_operations.id
+  region = var.primary_region
+  detector_id = data.aws_guardduty_detector.main.id
 
   auto_enable_organization_members = "ALL"
 }

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -38,17 +38,17 @@ resource "aws_guardduty_organization_configuration" "main" {
 resource "aws_guardduty_organization_configuration_feature" "main" {
   for_each = var.guardduty_organization_features
 
-  region = var.primary_region
+  region      = var.primary_region
   detector_id = data.aws_guardduty_detector.main.id
 
-  name = each.key
+  name        = each.key
   auto_enable = each.value.auto_enable
 
   dynamic "additional_configuration" {
     for_each = each.value.additiona_configuration
 
     content {
-      name = additional_configuration.key
+      name        = additional_configuration.key
       auto_enable = additional_configuration.value
     }
   }

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -35,6 +35,25 @@ resource "aws_guardduty_organization_configuration" "main" {
   auto_enable_organization_members = "ALL"
 }
 
+resource "aws_guardduty_organization_configuration_feature" "main" {
+  for_each = var.guardduty_organization_features
+
+  region = var.primary_region
+  detector_id = data.aws_guardduty_detector.main.id
+
+  name = each.key
+  auto_enable = each.value.auto_enable
+
+  dynamic "additional_configuration" {
+    for_each = each.value.additiona_configuration
+
+    content {
+      name = additional_configuration.key
+      auto_enable = additional_configuration.value
+    }
+  }
+}
+
 locals {
   name_prefix = "${var.cloud_name}-${var.environment}"
   securityhub_standard_catalog = {

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -95,3 +95,54 @@ variable "securityhub_cspm_account_policies" {
     error_message = "Each enabled Security Hub CSPM policy must contain at least one standard."
   }
 }
+
+variable "guardduty_organization_features" {
+  description = "GuardDuty protection plans centrally-managed across the AWS organization."
+
+  type = map(object({
+    auto_enable = optional(string, "ALL")
+
+    additional_configuration = optional(map(string), {})
+  }))
+
+  default = {
+    S3_DATA_EVENTS = {
+      auto_enable = "ALL"
+    }
+
+    EBS_MALWARE_PROTECTION = {
+        auto_enable = "ALL"
+    }
+
+    LAMBDA_NETWORK_LOGS = {
+        auto_enable = "ALL"
+    }
+
+    RUNTIME_MONITORING = {
+        auto_enable = "ALL"
+
+        additional_configuration = {
+            EC2_AGENT_MANAGEMENT = "ALL"
+        }
+    }
+  }
+
+  validation {
+    condition = alltrue([
+        for feature in values(var.guardduty_organization_features) :
+        contains(["ALL", "NEW", "NONE"], feature.auto_enable)
+    ])
+
+    error_message = "GuardDuty organization feature auto_enable values must be ALL, NEW, or NONE."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+        for feature in values(var.guardduty_organization_features) : [
+        contains(["ALL", "NEW", "NONE"], value)
+        ] 
+    ]))
+
+    error_message = "GuardDuty additional confiruation values must be ALL, NEW, or NONE."
+  }
+}

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -111,26 +111,26 @@ variable "guardduty_organization_features" {
     }
 
     EBS_MALWARE_PROTECTION = {
-        auto_enable = "ALL"
+      auto_enable = "ALL"
     }
 
     LAMBDA_NETWORK_LOGS = {
-        auto_enable = "ALL"
+      auto_enable = "ALL"
     }
 
     RUNTIME_MONITORING = {
-        auto_enable = "ALL"
+      auto_enable = "ALL"
 
-        additional_configuration = {
-            EC2_AGENT_MANAGEMENT = "ALL"
-        }
+      additional_configuration = {
+        EC2_AGENT_MANAGEMENT = "ALL"
+      }
     }
   }
 
   validation {
     condition = alltrue([
-        for feature in values(var.guardduty_organization_features) :
-        contains(["ALL", "NEW", "NONE"], feature.auto_enable)
+      for feature in values(var.guardduty_organization_features) :
+      contains(["ALL", "NEW", "NONE"], feature.auto_enable)
     ])
 
     error_message = "GuardDuty organization feature auto_enable values must be ALL, NEW, or NONE."
@@ -138,9 +138,9 @@ variable "guardduty_organization_features" {
 
   validation {
     condition = alltrue(flatten([
-        for feature in values(var.guardduty_organization_features) : [
+      for feature in values(var.guardduty_organization_features) : [
         contains(["ALL", "NEW", "NONE"], value)
-        ] 
+      ]
     ]))
 
     error_message = "GuardDuty additional confiruation values must be ALL, NEW, or NONE."

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -22,4 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
+  manage_guardduty_locally = var.manage_guardduty_locally
 }

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -22,5 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
-  manage_guardduty_locally = var.manage_guardduty_locally
+  manage_guardduty_locally           = var.manage_guardduty_locally
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -159,3 +159,9 @@ variable "manage_securityhub_cspm_locally" {
   type        = bool
   default     = false
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type        = bool
+  default     = false
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -22,4 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
+  manage_guardduty_locally = var.manage_guardduty_locally
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -22,5 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
-  manage_guardduty_locally = var.manage_guardduty_locally
+  manage_guardduty_locally           = var.manage_guardduty_locally
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -159,3 +159,9 @@ variable "manage_securityhub_cspm_locally" {
   type        = bool
   default     = false
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type        = bool
+  default     = false
+}

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -22,4 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
+  manage_guardduty_locally = var.manage_guardduty_locally
 }

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -22,5 +22,5 @@ module "baseline" {
   secops_emails                      = var.secops_emails
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
-  manage_guardduty_locally = var.manage_guardduty_locally
+  manage_guardduty_locally           = var.manage_guardduty_locally
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -159,3 +159,9 @@ variable "manage_securityhub_cspm_locally" {
   type        = bool
   default     = false
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type        = bool
+  default     = false
+}

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -18,6 +18,8 @@ resource "aws_ssm_service_setting" "block_ssm_doc_public_sharing" {
 
 # GUARDDUTY
 resource "aws_guardduty_detector" "main" {
+  count = var.manage_guardduty_locally ? 1 : 0
+
   enable                       = true
   finding_publishing_frequency = "FIFTEEN_MINUTES"
   region                       = var.primary_region

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -35,7 +35,7 @@ resource "aws_guardduty_detector" "main" {
 resource "aws_guardduty_detector_feature" "main" {
   for_each = var.manage_guardduty_locally ? toset(var.guardduty_features) : toset([])
 
-  detector_id = aws_guardduty_detector.main.id
+  detector_id = aws_guardduty_detector.main[0].id
   name        = each.value
   status      = "ENABLED"
 

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -34,7 +34,7 @@ resource "aws_guardduty_detector" "main" {
 ## LOOP THROUGH EACH FEATURE LISTED IN 'var.guardduty_features'
 resource "aws_guardduty_detector_feature" "main" {
   for_each    = var.manage_guardduty_locally ? toset(var.guardduty_features) : toset([])
-  
+
   detector_id = aws_guardduty_detector.main.id
   name        = each.value
   status      = "ENABLED"
@@ -52,8 +52,6 @@ resource "aws_securityhub_account" "main" {
   count = var.manage_securityhub_cspm_locally ? 1 : 0
 
   enable_default_standards = true
-
-  depends_on = [aws_guardduty_detector.main]
 }
 
 resource "aws_securityhub_account_v2" "main" {

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -33,7 +33,7 @@ resource "aws_guardduty_detector" "main" {
 
 ## LOOP THROUGH EACH FEATURE LISTED IN 'var.guardduty_features'
 resource "aws_guardduty_detector_feature" "main" {
-  for_each    = var.manage_guardduty_locally ? toset(var.guardduty_features) : toset([])
+  for_each = var.manage_guardduty_locally ? toset(var.guardduty_features) : toset([])
 
   detector_id = aws_guardduty_detector.main.id
   name        = each.value

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -33,7 +33,8 @@ resource "aws_guardduty_detector" "main" {
 
 ## LOOP THROUGH EACH FEATURE LISTED IN 'var.guardduty_features'
 resource "aws_guardduty_detector_feature" "main" {
-  for_each    = toset(var.guardduty_features)
+  for_each    = var.manage_guardduty_locally ? toset(var.guardduty_features) : toset([])
+  
   detector_id = aws_guardduty_detector.main.id
   name        = each.value
   status      = "ENABLED"

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -100,11 +100,11 @@ variable "sec_notifs_eventbridge_dlq_arn" {
 variable "manage_securityhub_cspm_locally" {
   description = "Whether this workload account manages its own Security Hub CSPM enablement and standards. Set to false when CSPM is centrally managed from the security-operations account."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -102,3 +102,9 @@ variable "manage_securityhub_cspm_locally" {
   type        = bool
   default     = false
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type = bool
+  default = false
+}

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -105,6 +105,6 @@ variable "manage_securityhub_cspm_locally" {
 
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
Closes #657 - Centralize `GuardDuty` in the `security-operations` AWS account