### PR TITLE
feat: Configure centralized `securityhub_v2` in the `security-operations` account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
-This update establishes centralized Security Hub CSPM governance through the
-security-operations account and refactors IAM Identity Center, validation, and
-GitHub Actions automation around consolidated multi-account configuration
-objects.
+This update establishes centralized Security Hub CSPM and GuardDuty governance
+through the security-operations account, adds the AWS Organizations foundations
+and workload policy model for Security Hub V2, and refactors IAM Identity
+Center, validation, and GitHub Actions automation around consolidated
+multi-account configuration objects.
 
 ### Added
 
@@ -14,8 +15,9 @@ objects.
   - account bootstrap and GitHub OIDC access; and
   - centralized security-service administration.
 - Added AWS Organizations structure for workload separation through:
-  - `Workloads/NonProd` for development and staging; and
-  - `Workloads/Prod` for production.
+  - `Workloads/NonProd` for development and staging;
+  - `Workloads/Prod` for production; and
+  - a dedicated `Security` OU for centralized security administration.
 - Added delegated-administrator registration for the security-operations
   account for Security Hub CSPM and GuardDuty administration.
 - Added centralized Security Hub CSPM configuration policies and account
@@ -26,9 +28,36 @@ objects.
   - enabled Security Hub standards; and
   - disabled control identifiers.
 - Added centralized Security Hub policy output maps for configuration-policy
-  IDs, ARNs, association targets, and discovered workload account IDs.
-- Added a dedicated security-operations IAM Identity Center access model with
-  the required `SecOps-Administrator` group and permission set.
+  IDs and association targets.
+- Added centralized GuardDuty organization configuration with organization
+  member auto-enrollment and centrally managed protection-plan settings.
+- Added centralized GuardDuty organization protection-plan configuration for:
+  - S3 data events;
+  - EBS malware protection;
+  - Lambda network logs; and
+  - Runtime Monitoring with EC2 agent management enabled and unused ECS/Fargate
+    and EKS agent-management integrations explicitly disabled.
+- Added the GuardDuty Malware Protection AWS Organizations trusted-service
+  access required for centralized EBS malware protection.
+- Added Security Hub V2 AWS Organizations prerequisites, including:
+  - `SECURITYHUB_POLICY` enablement;
+  - the Security Hub V2 service-linked role in the management account; and
+  - an AWS Organizations resource-based delegation policy allowing the
+    security-operations account to manage Security Hub organization policies.
+- Added Security Hub V2 administrator-account enablement in the
+  security-operations account.
+- Added a Security Hub V2 `SECURITYHUB_POLICY` for workload accounts in the
+  primary Region and associated it with the `Workloads` OU.
+- Added staged central-security rollout controls for:
+  - Security Hub CSPM organization configuration;
+  - GuardDuty organization configuration;
+  - Security Hub V2 organization policy management; and
+  - Security Hub V2 management-account Organizations prerequisites.
+- Added `manage_securityhub_v2_locally` support to the reusable workload
+  security path so standalone deployments can manage Security Hub V2 locally
+  while centrally governed environments can defer to AWS Organizations policy.
+- Added dedicated security-operations IAM Identity Center access with the
+  required `SecOps-Administrator` group and permission set.
 - Added consolidated IAM Identity Center GitHub Environment variables:
   - `IDENTITY_CENTER_WORKLOADS`; and
   - `IDENTITY_CENTER_SECOPS`.
@@ -43,6 +72,10 @@ objects.
   - account assignments across all four target accounts.
 - Added workload and security-operations account identifiers to exported
   control-plane validation evidence.
+- Added focused control-plane and security-operations Terraform outputs for
+  organization identifiers, OU identifiers, delegated-administrator ownership,
+  central security policy identifiers, and other values intended for future
+  centralized-security validation.
 
 ### Changed
 
@@ -52,6 +85,24 @@ objects.
 - Changed the workload Security Hub integration to support
   `manage_securityhub_cspm_locally = false` when an account is governed by the
   central CSPM policy.
+- Changed workload GuardDuty ownership to support
+  `manage_guardduty_locally = false` when GuardDuty is centrally governed by
+  the security-operations delegated administrator.
+- Changed workload Security Hub V2 ownership to support
+  `manage_securityhub_v2_locally = false` when Security Hub V2 is enabled by the
+  AWS Organizations workload policy.
+- Preserved standalone defaults for reusable security modules while setting
+  centralized `dev`, `staging`, and `prod` environments to defer Security Hub
+  CSPM, GuardDuty, and Security Hub V2 ownership to centralized governance.
+- Changed GuardDuty Runtime Monitoring additional configuration from unordered
+  map-based input to an ordered representation matching the AWS provider's
+  returned configuration and preventing perpetual replacement plans.
+- Imported the existing AWS Organization into Terraform ownership and enabled
+  `SECURITYHUB_POLICY` through the managed
+  `aws_organizations_organization` resource.
+- Changed the control-plane Organizations stack to use the managed
+  `aws_organizations_organization.main` resource directly instead of relying on
+  a redundant organization data source for resources owned by that stack.
 - Refactored three duplicated workload IAM Identity Center module calls into a
   single `module.identity_center_workload` block using `for_each` over
   `identity_center_workloads`.
@@ -87,6 +138,21 @@ objects.
 
 ### Fixed
 
+- Fixed GuardDuty Runtime Monitoring drift that caused Terraform to propose
+  replacement of the organization configuration feature when AWS returned
+  disabled ECS/Fargate and EKS sub-configurations alongside the enabled EC2
+  agent-management configuration.
+- Fixed centralized GuardDuty EBS malware protection configuration by enabling
+  the required `malware-protection.guardduty.amazonaws.com` Organizations
+  trusted-service access from the management account.
+- Fixed Security Hub V2 organization-policy creation from the delegated
+  security-operations account by extending the AWS Organizations delegation
+  policy to include policy tagging permissions required during policy creation.
+- Fixed the AWS Organizations bootstrap dependency path so a fresh deployment
+  can create the Organization before OU and account-discovery logic consumes
+  managed organization attributes.
+- Fixed conditional central-security resources and outputs so disabled rollout
+  controls do not require nonexistent indexed Terraform resource instances.
 - Fixed control-plane validation and evidence paths that still referenced the
   removed `ACCOUNT_ID_DEV`, `ACCOUNT_ID_STAGING`, and `ACCOUNT_ID_PROD`
   interface.
@@ -106,6 +172,16 @@ objects.
 
 - Centralized Security Hub CSPM standards and control configuration to reduce
   account-level drift across development, staging, and production.
+- Centralized GuardDuty organization enrollment and protection-plan governance
+  through the security-operations delegated administrator.
+- Added Security Hub V2 workload enablement through an AWS Organizations
+  `SECURITYHUB_POLICY` attached to the `Workloads` OU so current and future
+  workload accounts can inherit the approved primary-Region configuration.
+- Preserved explicit management-account versus delegated-administrator
+  ownership boundaries for trusted access, delegated administration, and
+  administrator-side security-service configuration.
+- Preserved workload-local deterministic remediation while centralizing
+  Security Hub CSPM, GuardDuty, and Security Hub V2 service governance.
 - Preserved separate workload and security-operations IAM Identity Center
   access models so workload Operator permissions are not reused as
   security-operations Administrator permissions.
@@ -117,6 +193,9 @@ objects.
 - Preserved customer-managed policy attachment requirements by continuing to
   reference workload policy names only after those policies exist in the
   target accounts.
+- Added opt-in rollout controls so reusable fresh deployments do not
+  automatically enable organization-wide central security governance until the
+  required delegated-administration prerequisites are established.
 
 ### Notes
 
@@ -129,9 +208,15 @@ objects.
   `control-plane`; do not include Bash-style outer single quotes.
 - Continue configuring the singular `ACCOUNT_ID` variable in each workload
   Plan and Apply GitHub Environment.
-- Security Hub CSPM central configuration is complete for the current workload
-  accounts. Security Hub V2 remains locally enabled, and full Security Hub V2
-  and GuardDuty organization-wide centralization remain future work.
+- Security Hub CSPM central configuration and GuardDuty organization
+  centralization are implemented for the current centralized architecture.
+- Security Hub V2 administrator enablement and workload organization-policy
+  governance are implemented in the primary Region; workload Terraform now
+  defers local V2 ownership when centralized governance is enabled.
+- The centralized-security implementation is not yet a `v1.7.0` release.
+  Security-operations validation/evidence scripts, CI/CD workflow integration,
+  documentation updates, and final release validation remain to be completed
+  before the next release is tagged.
 
 ## v1.6.0
 

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -126,6 +126,7 @@ module "security" {
   centralized_logs_bucket_name = module.storage.centralized_logs_bucket_name
 
   manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
+  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
   manage_guardduty_locally        = var.manage_guardduty_locally
   guardduty_features              = var.guardduty_features
   enable_rules                    = local.effective_enable_rules

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -126,7 +126,7 @@ module "security" {
   centralized_logs_bucket_name = module.storage.centralized_logs_bucket_name
 
   manage_securityhub_cspm_locally = var.manage_securityhub_cspm_locally
-  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
+  manage_securityhub_v2_locally   = var.manage_securityhub_v2_locally
   manage_guardduty_locally        = var.manage_guardduty_locally
   guardduty_features              = var.guardduty_features
   enable_rules                    = local.effective_enable_rules

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -287,3 +287,9 @@ variable "manage_guardduty_locally" {
   type        = bool
   default     = true
 }
+
+variable "manage_guardduty_locally" {
+  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+  type        = bool
+  default     = true
+}

--- a/baseline/variables.tf
+++ b/baseline/variables.tf
@@ -282,8 +282,8 @@ variable "manage_securityhub_cspm_locally" {
   default     = true
 }
 
-variable "manage_guardduty_locally" {
-  description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
+variable "manage_securityhub_v2_locally" {
+  description = "Whether this module manages Security Hub V2 directly in the workload account"
   type        = bool
   default     = true
 }

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -79,6 +79,11 @@ resource "aws_securityhub_organization_admin_account" "security_operations" {
   ]
 }
 
+resource "aws_iam_service_linked_role" "securityhub_v2" {
+  aws_service_name = "securityhubv2.amazonaws.com"
+  description = "Service-linked role for AWS Security Hub V2 organization management"
+}
+
 ##########################################
 # GUARDDUTY ORGANIZATION INTEGRATION
 ##########################################

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -38,10 +38,6 @@ resource "aws_organizations_organizational_unit" "security" {
   parent_id = data.aws_organizations_organization.main.roots[0].id
 }
 
-##########################################
-# SECURITY HUB ORGANIZATION INTEGRATION
-##########################################
-
 locals {
   security_operations_accounts = [
     for account in data.aws_organizations_organization.main.accounts :
@@ -64,6 +60,10 @@ check "security_operations_account" {
     error_message = "Exactly one AWS Organizations account name '${var.security_operations_account_name}' must exist."
   }
 }
+
+##########################################
+# SECURITY HUB ORGANIZATION INTEGRATION
+##########################################
 
 resource "aws_organizations_aws_service_access" "securityhub" {
   count = var.enable_securityhub_delegated_administrator ? 1 : 0

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -16,11 +16,9 @@ resource "aws_organizations_organization" "main" {
   }
 }
 
-data "aws_organizations_organization" "main" {}
-
 resource "aws_organizations_organizational_unit" "workloads" {
   name      = "Workloads"
-  parent_id = data.aws_organizations_organization.main.roots[0].id
+  parent_id = aws_organizations_organization.main.roots[0].id
 }
 
 resource "aws_organizations_organizational_unit" "nonprod" {
@@ -35,12 +33,12 @@ resource "aws_organizations_organizational_unit" "prod" {
 
 resource "aws_organizations_organizational_unit" "security" {
   name      = "Security"
-  parent_id = data.aws_organizations_organization.main.roots[0].id
+  parent_id = aws_organizations_organization.main.roots[0].id
 }
 
 locals {
   security_operations_accounts = [
-    for account in data.aws_organizations_organization.main.accounts :
+    for account in aws_organizations_organization.main.accounts :
     account
     if account.name == var.security_operations_account_name
   ]

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -1,12 +1,18 @@
-/*
-If AWS Organizations is not already enabled in the account, uncomment this resource
 resource "aws_organizations_organization" "main" {
   feature_set = "ALL"
 
-  aws_service_access_principals = []
-  enabled_policy_types          = []
+  enabled_policy_types = [
+    "SECURITYHUB_POLICY",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+
+    ignore_changes = [
+      aws_service_access_principals,
+    ]
+  }
 }
-*/
 
 data "aws_organizations_organization" "main" {}
 

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_organizations_organization" "main" {
   feature_set = "ALL"
 

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -86,7 +86,7 @@ resource "aws_iam_service_linked_role" "securityhub_v2" {
 
 data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
   statement {
-    sid = "SecurityHubV2OrganizationRead"
+    sid    = "SecurityHubV2OrganizationRead"
     effect = "Allow"
 
     principals {
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
   }
 
   statement {
-    sid = "SecurityHubV2PolicyRead"
+    sid    = "SecurityHubV2PolicyRead"
     effect = "Allow"
 
     principals {
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
     resources = ["*"]
 
     condition {
-      test = "StringLikeIfExists"
+      test     = "StringLikeIfExists"
       variable = "organizations:PolicyType"
 
       values = [
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
   }
 
   statement {
-    sid = "SecurityHubV2PolicyManagement"
+    sid    = "SecurityHubV2PolicyManagement"
     effect = "Allow"
 
     principals {
@@ -170,7 +170,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
     ]
 
     condition {
-      test = "StringLikeIfExists"
+      test     = "StringLikeIfExists"
       variable = "organization:PolicyType"
 
       values = [

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -178,6 +178,27 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
       ]
     }
   }
+
+  statement {
+    sid    = "SecurityHubV2PolicyTagging"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.security_operations_account_id}:root"
+      ]
+    }
+
+    actions = [
+      "organizations:TagResource",
+      "organizations:UntagResource",
+    ]
+
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:policy/${aws_organizations_organization.main.id}/securityhub_policy/*",
+    ]
+  }
 }
 
 resource "aws_organizations_resource_policy" "securityhub_v2" {

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -79,6 +79,10 @@ resource "aws_securityhub_organization_admin_account" "security_operations" {
   ]
 }
 
+##########################################
+# GUARDDUTY ORGANIZATION INTEGRATION
+##########################################
+
 resource "aws_organizations_aws_service_access" "guardduty" {
   count = var.enable_guardduty_delegated_administrator ? 1 : 0
 

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
     principals {
       type = "AWS"
       identifiers = [
-        "aws:aws:iam::${local.security_operations_account_id}:root"
+        "arn:aws:iam::${local.security_operations_account_id}:root"
       ]
     }
 
@@ -171,7 +171,7 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
 
     condition {
       test     = "StringLikeIfExists"
-      variable = "organization:PolicyType"
+      variable = "organizations:PolicyType"
 
       values = [
         "SECURITYHUB_POLICY",

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -80,11 +80,15 @@ resource "aws_securityhub_organization_admin_account" "security_operations" {
 }
 
 resource "aws_iam_service_linked_role" "securityhub_v2" {
+  count = var.enable_securityhub_v2_organization_management ? 1 : 0
+
   aws_service_name = "securityhubv2.amazonaws.com"
   description      = "Service-linked role for AWS Security Hub V2 organization management"
 }
 
 data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
+  count = var.enable_securityhub_v2_organization_management ? 1 : 0
+
   statement {
     sid    = "SecurityHubV2OrganizationRead"
     effect = "Allow"
@@ -202,7 +206,9 @@ data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
 }
 
 resource "aws_organizations_resource_policy" "securityhub_v2" {
-  content = data.aws_iam_policy_document.securityhub_v2_organizations_delegation.json
+  count = var.enable_securityhub_v2_organization_management ? 1 : 0
+
+  content = data.aws_iam_policy_document.securityhub_v2_organizations_delegation[0].json
 
   depends_on = [
     aws_iam_service_linked_role.securityhub_v2,

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -3,9 +3,9 @@ data "aws_caller_identity" "current" {}
 resource "aws_organizations_organization" "main" {
   feature_set = "ALL"
 
-  enabled_policy_types = [
+  enabled_policy_types = var.enable_securityhub_v2_organization_management ? [
     "SECURITYHUB_POLICY",
-  ]
+  ] : []
 
   lifecycle {
     prevent_destroy = true

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -81,7 +81,7 @@ resource "aws_securityhub_organization_admin_account" "security_operations" {
 
 resource "aws_iam_service_linked_role" "securityhub_v2" {
   aws_service_name = "securityhubv2.amazonaws.com"
-  description = "Service-linked role for AWS Security Hub V2 organization management"
+  description      = "Service-linked role for AWS Security Hub V2 organization management"
 }
 
 ##########################################

--- a/bootstrap/control_plane/organizations/main.tf
+++ b/bootstrap/control_plane/organizations/main.tf
@@ -84,6 +84,112 @@ resource "aws_iam_service_linked_role" "securityhub_v2" {
   description      = "Service-linked role for AWS Security Hub V2 organization management"
 }
 
+data "aws_iam_policy_document" "securityhub_v2_organizations_delegation" {
+  statement {
+    sid = "SecurityHubV2OrganizationRead"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.security_operations_account_id}:root"
+      ]
+    }
+
+    actions = [
+      "organizations:DescribeOrganization",
+      "organizations:DescribeOrganizationalUnit",
+      "organizations:DescribeAccount",
+      "organizations:ListRoots",
+      "organizations:ListOrganizationalUnitsForParent",
+      "organizations:ListParents",
+      "organizations:ListChildren",
+      "organizations:ListAccounts",
+      "organizations:ListAccountsForParent",
+      "organizations:ListTagsForResource",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SecurityHubV2PolicyRead"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "aws:aws:iam::${local.security_operations_account_id}:root"
+      ]
+    }
+
+    actions = [
+      "organizations:DescribePolicy",
+      "organizations:DescribeEffectivePolicy",
+      "organizations:ListPolicies",
+      "organizations:ListPoliciesForTarget",
+      "organizations:ListTargetsForPolicy",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test = "StringLikeIfExists"
+      variable = "organizations:PolicyType"
+
+      values = [
+        "SECURITYHUB_POLICY",
+      ]
+    }
+  }
+
+  statement {
+    sid = "SecurityHubV2PolicyManagement"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.security_operations_account_id}:root"
+      ]
+    }
+
+    actions = [
+      "organizations:CreatePolicy",
+      "organizations:UpdatePolicy",
+      "organizations:DeletePolicy",
+      "organizations:AttachPolicy",
+      "organizations:DetachPolicy",
+    ]
+
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:root/${aws_organizations_organization.main.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.main.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.main.id}/*",
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:policy/${aws_organizations_organization.main.id}/securityhub_policy/*",
+    ]
+
+    condition {
+      test = "StringLikeIfExists"
+      variable = "organization:PolicyType"
+
+      values = [
+        "SECURITYHUB_POLICY",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_resource_policy" "securityhub_v2" {
+  content = data.aws_iam_policy_document.securityhub_v2_organizations_delegation.json
+
+  depends_on = [
+    aws_iam_service_linked_role.securityhub_v2,
+    aws_organizations_organization.main,
+    aws_securityhub_organization_admin_account.security_operations,
+  ]
+}
+
 ##########################################
 # GUARDDUTY ORGANIZATION INTEGRATION
 ##########################################

--- a/bootstrap/control_plane/organizations/outputs.tf
+++ b/bootstrap/control_plane/organizations/outputs.tf
@@ -24,6 +24,16 @@ output "security_operations_account_id" {
   value       = local.security_operations_account_id
 }
 
+output "central_security_features_enabled" {
+  description = "Central security administration capabilities enabled by this stack"
+
+  value = {
+    securityhub_delegated_administrator    = var.enable_securityhub_delegated_administrator
+    guardduty_delegated_administrator      = var.enable_guardduty_delegated_administrator
+    securityhub_v2_organization_management = var.enable_securityhub_v2_organization_management
+  }
+}
+
 output "delegated_administrator_account_ids" {
   description = "AWS account IDs configured as delegated administrators for centralized security services"
 
@@ -38,9 +48,4 @@ output "delegated_administrator_account_ids" {
       null
     )
   }
-}
-
-output "securityhub_trusted_access_enabled" {
-  description = "Whether this stack manages trusted access for Security Hub"
-  value       = length(aws_organizations_aws_service_access.securityhub) == 1
 }

--- a/bootstrap/control_plane/organizations/outputs.tf
+++ b/bootstrap/control_plane/organizations/outputs.tf
@@ -1,9 +1,43 @@
-output "securityhub_delegated_administrator_account_id" {
-  description = "Account ID designated as the Security Hub administrator"
-  value = try(
-    aws_securityhub_organization_admin_account.security_operations[0].admin_account_id,
-    null
-  )
+output "organization_id" {
+  description = "AWS Organizations organization ID"
+  value       = aws_organizations_organization.main.id
+}
+
+output "organization_root_id" {
+  description = "AWS Organizations root ID"
+  value       = aws_organizations_organization.main.roots[0].id
+}
+
+output "organizational_unit_ids" {
+  description = "AWS Organizations organizational unit IDs managed by this stack"
+
+  value = {
+    workloads = aws_organizations_organizational_unit.workloads.id
+    nonprod   = aws_organizations_organizational_unit.nonprod.id
+    prod      = aws_organizations_organizational_unit.prod.id
+    security  = aws_organizations_organizational_unit.security.id
+  }
+}
+
+output "security_operations_account_id" {
+  description = "AWS account ID used for centralized security operations"
+  value       = local.security_operations_account_id
+}
+
+output "delegated_administrator_account_ids" {
+  description = "AWS account IDs configured as delegated administrators for centralized security services"
+
+  value = {
+    securityhub = try(
+      aws_securityhub_organization_admin_account.security_operations[0].admin_account_id,
+      null
+    )
+
+    guardduty = try(
+      aws_guardduty_organization_admin_account.security_operations[0].admin_account_id,
+      null
+    )
+  }
 }
 
 output "securityhub_trusted_access_enabled" {

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -15,3 +15,9 @@ variable "enable_guardduty_delegated_administrator" {
   type    = bool
   default = false
 }
+
+variable "enable_securityhub_v2_organization_management" {
+  description = "Enable AWS Organizations prerequisites for centralized Security Hub V2 management"
+  type        = bool
+  default     = false
+}

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -12,8 +12,8 @@ variable "security_operations_account_name" {
 
 variable "enable_guardduty_delegated_administrator" {
   description = "Enable GuardDuty trusted access and designate the security-operations account as administrator"
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "enable_securityhub_v2_organization_management" {

--- a/bootstrap/control_plane/organizations/variables.tf
+++ b/bootstrap/control_plane/organizations/variables.tf
@@ -11,6 +11,7 @@ variable "security_operations_account_name" {
 }
 
 variable "enable_guardduty_delegated_administrator" {
+  description = "Enable GuardDuty trusted access and designate the security-operations account as administrator"
   type    = bool
   default = false
 }

--- a/bootstrap/security_operations/security_services/README.md
+++ b/bootstrap/security_operations/security_services/README.md
@@ -1,0 +1,282 @@
+# Security Operations Security Services
+
+This Terraform root configures centralized AWS security-service administration
+from the dedicated `security-operations` account.
+
+It is intentionally separate from the AWS Organizations management-account
+stack. The control-plane Organizations stack establishes organization-level
+prerequisites such as trusted service access, delegated-administrator
+registration, the Security Hub V2 policy type, and management-account
+service-linked/delegation resources. This stack owns the delegated
+administrator-side Security Hub CSPM, GuardDuty, and Security Hub V2
+configuration.
+
+## Responsibilities
+
+This stack currently manages:
+
+- Security Hub CSPM in the `security-operations` account;
+- the Security Hub finding aggregator for the current single-Region model;
+- Security Hub CSPM central organization configuration;
+- per-account Security Hub CSPM configuration policies and associations;
+- the existing GuardDuty delegated-administrator detector by discovery;
+- GuardDuty organization member enrollment and protection-plan configuration;
+- Security Hub V2 enablement in the `security-operations` account; and
+- the Security Hub V2 AWS Organizations policy attached to the root-level
+  `Workloads` OU.
+
+It does **not** own:
+
+- AWS Organizations creation or OU creation;
+- trusted service access;
+- Security Hub or GuardDuty delegated-administrator registration;
+- management-account Security Hub V2 prerequisites;
+- workload-local remediation, EventBridge rules, or Lambda response logic; or
+- workload-local Security Hub CSPM, GuardDuty, or Security Hub V2 resources
+  when centralized ownership is enabled.
+
+Those boundaries are intentional so management-account governance,
+administrator-side security services, and workload-local response remain
+separate Terraform ownership domains.
+
+## Prerequisites
+
+Before applying this stack:
+
+1. The `security-operations` account must exist and be a member of the AWS
+   Organization.
+2. The control-plane Organizations stack must have established the required
+   delegated-administrator and trusted-access prerequisites.
+3. GuardDuty must already be enabled for the `security-operations` delegated
+   administrator in the configured Region.
+4. If Security Hub V2 organization policy management is enabled, exactly one
+   root-level OU named `Workloads` must exist.
+5. Any workload account named in `securityhub_cspm_account_policies` and marked
+   for association must exist as exactly one active AWS Organizations account.
+
+The stack also checks that the active AWS credentials belong to the configured
+`account_id`.
+
+## Centralization Rollout Controls
+
+Organization-wide behavior is opt-in.
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `enable_securityhub_organization_configuration` | `false` | Enables Security Hub CSPM central organization configuration. |
+| `enable_guardduty_organization_configuration` | `false` | Enables GuardDuty organization enrollment and centrally managed protection plans. |
+| `enable_securityhub_v2_organization_policy` | `false` | Creates and attaches the Security Hub V2 Organizations policy to the `Workloads` OU. |
+
+This allows delegated administration and administrator-account resources to be
+established before organization-wide governance is enabled.
+
+For the centralized project deployment, these controls are expected to be
+enabled after the corresponding management-account prerequisites have been
+applied.
+
+## Security Hub CSPM
+
+Security Hub CSPM is enabled in the `security-operations` account with default
+standards and automatic control enablement disabled:
+
+```hcl
+enable_default_standards = false
+auto_enable_controls     = false
+```
+
+The finding aggregator uses:
+
+```hcl
+linking_mode = "NO_REGIONS"
+```
+
+which matches the current single-Region architecture.
+
+When `enable_securityhub_organization_configuration = true`, the stack enables
+central organization configuration with:
+
+```text
+configuration_type      = CENTRAL
+auto_enable             = false
+auto_enable_standards   = NONE
+```
+
+Workload configuration is controlled through
+`securityhub_cspm_account_policies`.
+
+Example:
+
+```hcl
+securityhub_cspm_account_policies = {
+  dev = {
+    create_policy    = true
+    associate_policy = true
+
+    enabled_standards = [
+      "aws_fsbp",
+      "cis_5_0",
+    ]
+
+    disabled_control_identifiers = []
+  }
+}
+```
+
+Supported standard keys are:
+
+- `aws_fsbp`
+- `aws_tagging`
+- `cis_1_2`
+- `cis_5_0`
+- `nist_800_53`
+- `pci_dss`
+
+Policy-map keys are resolved against active AWS Organizations account names
+before associations are created.
+
+## GuardDuty
+
+The GuardDuty detector is discovered rather than created:
+
+```hcl
+data "aws_guardduty_detector" "main"
+```
+
+This preserves the detector created when the account became the GuardDuty
+delegated administrator.
+
+When `enable_guardduty_organization_configuration = true`, organization member
+auto-enrollment is set to:
+
+```text
+ALL
+```
+
+The default centrally managed protection plans are:
+
+| Feature | Auto-enable |
+| --- | --- |
+| S3 data events | `ALL` |
+| EBS malware protection | `ALL` |
+| Lambda network logs | `ALL` |
+| Runtime Monitoring | `ALL` |
+
+Runtime Monitoring additional configuration defaults to:
+
+| Configuration | Auto-enable |
+| --- | --- |
+| `EC2_AGENT_MANAGEMENT` | `ALL` |
+| `ECS_FARGATE_AGENT_MANAGEMENT` | `NONE` |
+| `EKS_ADDON_MANAGEMENT` | `NONE` |
+
+The additional configuration is modeled as an ordered list to match the AWS
+provider's ordered GuardDuty configuration behavior.
+
+## Security Hub V2
+
+Security Hub V2 is enabled directly in the `security-operations` account.
+
+When `enable_securityhub_v2_organization_policy = true`, this stack creates an
+AWS Organizations policy of type:
+
+```text
+SECURITYHUB_POLICY
+```
+
+The policy enables Security Hub V2 in `primary_region` and is attached to the
+root-level `Workloads` OU. Workload accounts beneath that OU inherit the
+organization policy.
+
+Workload Terraform should use:
+
+```hcl
+manage_securityhub_v2_locally = false
+```
+
+when the account is governed by this centralized policy.
+
+Management-account prerequisites for `SECURITYHUB_POLICY` are owned by
+`bootstrap/control_plane/organizations` and are intentionally not duplicated
+here.
+
+## Inputs
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cloud_name` | `string` | required | Cloud/platform name used for naming. |
+| `environment` | `string` | required | Must be `security-operations`. |
+| `primary_region` | `string` | required | Primary Region and Security Hub home Region. |
+| `account_id` | `string` | required | 12-digit security-operations AWS account ID. |
+| `enable_securityhub_organization_configuration` | `bool` | `false` | Enables central Security Hub CSPM organization configuration. |
+| `securityhub_cspm_account_policies` | `map(object)` | `{}` | Per-account CSPM policy and association configuration. |
+| `enable_guardduty_organization_configuration` | `bool` | `false` | Enables GuardDuty organization configuration. |
+| `guardduty_organization_features` | `map(object)` | see `variables.tf` | GuardDuty organization protection-plan configuration. |
+| `enable_securityhub_v2_organization_policy` | `bool` | `false` | Enables the workload Security Hub V2 Organizations policy. |
+
+See `variables.tf` for the complete object schemas and validation rules.
+
+## Outputs
+
+The stack exposes a deliberately small set of identifiers and expected
+configuration values for downstream validation and evidence tooling:
+
+- `security_operations_account_id`
+- `securityhub_home_region`
+- `central_security_features_enabled`
+- `securityhub_finding_aggregator_arn`
+- `securityhub_cspm_configuration_policy_ids`
+- `securityhub_cspm_policy_association_target_ids`
+- `guardduty_detector_id`
+- `securityhub_v2_organization_policy_id`
+
+These outputs describe Terraform intent and stable resource identifiers.
+Validation scripts should still query AWS directly to verify effective live
+configuration.
+
+## Backend
+
+State is stored in the dedicated security-operations S3 backend:
+
+```text
+bucket: tf-secure-baseline-security-operations-state
+key:    security-operation/security-services.tfstate
+region: us-east-1
+```
+
+Native S3 state locking is enabled with `use_lockfile = true`.
+
+## Deployment
+
+From this directory:
+
+```bash
+terraform init
+terraform fmt -check
+terraform validate
+AWS_PROFILE=security-operations terraform plan
+AWS_PROFILE=security-operations terraform apply
+```
+
+Apply the control-plane Organizations stack first whenever delegated
+administration, trusted access, Security Hub V2 policy prerequisites, or other
+management-account dependencies change.
+
+After applying this stack, validate the effective organization configuration
+before deploying or reconciling workload environments.
+
+## Validation
+
+Centralized security validation should verify live AWS state rather than rely
+only on Terraform state. The planned `validate-security-operations.sh` workflow
+should cover, at minimum:
+
+- the expected security-operations account and Region;
+- Security Hub delegated administration and central configuration;
+- CSPM configuration-policy associations;
+- GuardDuty detector status, organization enrollment, and protection plans;
+- Security Hub V2 administrator enablement;
+- the `SECURITYHUB_POLICY` attachment and effective workload policy; and
+- expected workload account placement beneath the `Workloads` OU.
+
+Terraform outputs from this stack provide expected identifiers; AWS API
+responses provide the effective-state validation evidence.

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -33,6 +33,8 @@ check "guardduty_detector_enabled" {
 ##########################################
 
 resource "aws_guardduty_organization_configuration" "main" {
+  count = var.enable_guardduty_organization_configuration ? 1 : 0
+
   region      = var.primary_region
   detector_id = data.aws_guardduty_detector.main.id
 
@@ -40,7 +42,7 @@ resource "aws_guardduty_organization_configuration" "main" {
 }
 
 resource "aws_guardduty_organization_configuration_feature" "main" {
-  for_each = var.guardduty_organization_features
+  for_each = var.enable_guardduty_organization_configuration ? var.guardduty_organization_features : {}
 
   region      = var.primary_region
   detector_id = data.aws_guardduty_detector.main.id

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -250,9 +250,9 @@ resource "aws_securityhub_account_v2" "main" {
 }
 
 resource "aws_organizations_policy" "securityhub_v2_workloads" {
-  name = "${local.name_prefix}-securityhub_v2_workloads"
+  name        = "${local.name_prefix}-securityhub_v2_workloads"
   description = "Central Security Hub V2 policy for workload accounts"
-  type = "SECURITYHUB_POLICY"
+  type        = "SECURITYHUB_POLICY"
 
   content = jsonencode({
     securityhub = {
@@ -269,9 +269,9 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
   })
 
   tags = {
-    Name = "${local.name_prefix}-securityhub-v2-workloads"
+    Name        = "${local.name_prefix}-securityhub-v2-workloads"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 
   depends_on = [

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -282,7 +282,7 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
   }
 
   depends_on = [
-    aws_securityhub_account_v2.main[0],
+    aws_securityhub_account_v2.main,
   ]
 }
 

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -1,5 +1,9 @@
 data "aws_organizations_organization" "main" {}
 
+data "aws_organizations_organizational_units" "root" {
+  parent_id = data.aws_organizations_organization.main.roots[0].id
+}
+
 data "aws_caller_identity" "current" {}
 
 check "target_account" {
@@ -102,6 +106,17 @@ locals {
       null
     )
   }
+
+  workloads_ous = [
+    for ou in data.aws_organizations_organizational_units.root.children :
+    ou
+    if ou.name == "Workloads"
+  ]
+
+  workloads_ou_id = try(
+    one(local.workloads_ous).id,
+    null
+  )
 }
 
 check "securityhub_cspm_association_accounts" {
@@ -112,6 +127,13 @@ check "securityhub_cspm_association_accounts" {
     ])
 
     error_message = "Each associated Security Hub CSPM policy must match exactly one active AWS Organizations accoutn using the policy map key as the account name."
+  }
+}
+
+check "workloads_ou" {
+  assert {
+    condition = length(local.workloads_ous) == 1
+    error_message = "Exactly one root-level AWS Organizations OU named 'Workloads' must exist."
   }
 }
 

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -134,7 +134,7 @@ check "securityhub_cspm_association_accounts" {
 
 check "workloads_ou" {
   assert {
-    condition     = (
+    condition = (
       !var.enable_securityhub_v2_organization_policy ||
       length(local.workloads_ous) == 1
     )

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -289,7 +289,7 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
 resource "aws_organizations_policy_attachment" "securityhub_v2_workloads" {
   count = var.enable_securityhub_v2_organization_policy ? 1 : 0
 
-  policy_id = aws_organizations_policy.securityhub_v2_workloads.id
+  policy_id = aws_organizations_policy.securityhub_v2_workloads[0].id
   target_id = local.workloads_ou_id
 
   depends_on = [

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -248,3 +248,33 @@ resource "aws_securityhub_account_v2" "main" {
     aws_securityhub_account.main,
   ]
 }
+
+resource "aws_organizations_policy" "securityhub_v2_workloads" {
+  name = "${local.name_prefix}-securityhub_v2_workloads"
+  description = "Central Security Hub V2 policy for workload accounts"
+  type = "SECURITYHUB_POLICY"
+
+  content = jsonencode({
+    securityhub = {
+      enable_in_regions = {
+        "@@assign" = [
+          var.primary_region
+        ]
+      }
+
+      disable_in_regions = {
+        "@@assign" = []
+      }
+    }
+  })
+
+  tags = {
+    Name = "${local.name_prefix}-securityhub-v2-workloads"
+    Environment = var.environment
+    Terraform = "true"
+  }
+
+  depends_on = [
+    aws_securityhub_account_v2.main,
+  ]
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -134,8 +134,11 @@ check "securityhub_cspm_association_accounts" {
 
 check "workloads_ou" {
   assert {
-    condition     = length(local.workloads_ous) == 1
-    error_message = "Exactly one root-level AWS Organizations OU named 'Workloads' must exist."
+    condition     = (
+      !var.enable_securityhub_v2_organization_policy ||
+      length(local.workloads_ous) == 1
+    )
+    error_message = "Exactly one root-level AWS Organizations OU named 'Workloads' must exist when Security Hub V2 organization policy management is enabled."
   }
 }
 
@@ -285,7 +288,7 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
 
 resource "aws_organizations_policy_attachment" "securityhub_v2_workloads" {
   count = var.enable_securityhub_v2_organization_policy ? 1 : 0
-  
+
   policy_id = aws_organizations_policy.securityhub_v2_workloads.id
   target_id = local.workloads_ou_id
 

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -230,3 +230,21 @@ resource "aws_securityhub_configuration_policy_association" "account" {
     }
   }
 }
+
+##########################################
+# SECURITY HUB V2 ADMINISTRATOR ACCOUNT
+##########################################
+
+resource "aws_securityhub_account_v2" "main" {
+  region = var.primary_region
+
+  tags = {
+    Name = "${local.name_prefix}-securityhub-v2"
+    Environment = var.environment
+    Terraform = "true"
+  }
+
+  depends_on = [
+    aws_securityhub_account.main,
+  ]
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -252,6 +252,8 @@ resource "aws_securityhub_account_v2" "main" {
 }
 
 resource "aws_organizations_policy" "securityhub_v2_workloads" {
+  count = var.enable_securityhub_v2_organization_policy ? 1 : 0
+
   name        = "${local.name_prefix}-securityhub_v2_workloads"
   description = "Central Security Hub V2 policy for workload accounts"
   type        = "SECURITYHUB_POLICY"
@@ -282,6 +284,8 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
 }
 
 resource "aws_organizations_policy_attachment" "securityhub_v2_workloads" {
+  count = var.enable_securityhub_v2_organization_policy ? 1 : 0
+  
   policy_id = aws_organizations_policy.securityhub_v2_workloads.id
   target_id = local.workloads_ou_id
 

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -132,7 +132,7 @@ check "securityhub_cspm_association_accounts" {
 
 check "workloads_ou" {
   assert {
-    condition = length(local.workloads_ous) == 1
+    condition     = length(local.workloads_ous) == 1
     error_message = "Exactly one root-level AWS Organizations OU named 'Workloads' must exist."
   }
 }

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -239,9 +239,9 @@ resource "aws_securityhub_account_v2" "main" {
   region = var.primary_region
 
   tags = {
-    Name = "${local.name_prefix}-securityhub-v2"
+    Name        = "${local.name_prefix}-securityhub-v2"
     Environment = var.environment
-    Terraform = "true"
+    Terraform   = "true"
   }
 
   depends_on = [

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -52,7 +52,7 @@ resource "aws_guardduty_organization_configuration_feature" "main" {
     for_each = each.value.additional_configuration
 
     content {
-      name        = additional_configuration.value.key
+      name        = additional_configuration.value.name
       auto_enable = additional_configuration.value.auto_enable
     }
   }

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -278,3 +278,12 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
     aws_securityhub_account_v2.main,
   ]
 }
+
+resource "aws_organizations_policy_attachment" "securityhub_v2_workloads" {
+  policy_id = aws_organizations_policy.securityhub_v2_workloads.id
+  target_id = local.workloads_ou_id
+
+  depends_on = [
+    aws_organizations_policy.securityhub_v2_workloads,
+  ]
+}

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -52,8 +52,8 @@ resource "aws_guardduty_organization_configuration_feature" "main" {
     for_each = each.value.additional_configuration
 
     content {
-      name        = additional_configuration.key
-      auto_enable = additional_configuration.value
+      name        = additional_configuration.value.key
+      auto_enable = additional_configuration.value.auto_enable
     }
   }
 }

--- a/bootstrap/security_operations/security_services/main.tf
+++ b/bootstrap/security_operations/security_services/main.tf
@@ -282,7 +282,7 @@ resource "aws_organizations_policy" "securityhub_v2_workloads" {
   }
 
   depends_on = [
-    aws_securityhub_account_v2.main,
+    aws_securityhub_account_v2.main[0],
   ]
 }
 

--- a/bootstrap/security_operations/security_services/outputs.tf
+++ b/bootstrap/security_operations/security_services/outputs.tf
@@ -57,7 +57,7 @@ output "guardduty_detector_id" {
 
 output "guardduty_auto_enable_organization_members" {
   description = "GuardDuty organization member auto-enablement mode."
-  value       = aws_guardduty_organization_configuration.main.auto_enable_organization_members
+  value       = aws_guardduty_organization_configuration.main[0].auto_enable_organization_members
 }
 
 output "guardduty_organization_features" {

--- a/bootstrap/security_operations/security_services/outputs.tf
+++ b/bootstrap/security_operations/security_services/outputs.tf
@@ -8,14 +8,19 @@ output "securityhub_home_region" {
   value       = var.primary_region
 }
 
+output "central_security_features_enabled" {
+  description = "Central security-service capabilities enabled by this stack"
+
+  value = {
+    securityhub_cspm = var.enable_securityhub_organization_configuration
+    guardduty        = var.enable_guardduty_organization_configuration
+    securityhub_v2   = var.enable_securityhub_v2_organization_policy
+  }
+}
+
 output "securityhub_finding_aggregator_arn" {
   description = "ARN of the Security Hub finding aggregator"
   value       = aws_securityhub_finding_aggregator.main.arn
-}
-
-output "securityhub_central_configuration_enabled" {
-  description = "Whether Security Hub central organization configuration is enabled"
-  value       = var.enable_securityhub_organization_configuration
 }
 
 output "securityhub_cspm_configuration_policy_ids" {
@@ -24,15 +29,6 @@ output "securityhub_cspm_configuration_policy_ids" {
   value = {
     for account_name, policy in aws_securityhub_configuration_policy.account :
     account_name => policy.id
-  }
-}
-
-output "securityhub_cspm_configuration_policy_arns" {
-  description = "Security Hub CSPM configuration policy ARNs by AWS Organizations account name"
-
-  value = {
-    for account_name, policy in aws_securityhub_configuration_policy.account :
-    account_name => policy.arn
   }
 }
 
@@ -45,28 +41,16 @@ output "securityhub_cspm_policy_association_target_ids" {
   }
 }
 
-output "securityhub_cspm_account_ids" {
-  description = "AWS Organizations account IDs discovered for Security Hub CSPM policy associations"
-  value       = local.securityhub_cspm_association_account_ids
-}
-
 output "guardduty_detector_id" {
-  description = "GuardDuty detector ID for the security-operations delegated administrator account."
+  description = "GuardDuty detector ID for the security-operations delegated administrator account"
   value       = data.aws_guardduty_detector.main.id
 }
 
-output "guardduty_auto_enable_organization_members" {
-  description = "GuardDuty organization member auto-enablement mode."
-  value       = aws_guardduty_organization_configuration.main[0].auto_enable_organization_members
-}
+output "securityhub_v2_organization_policy_id" {
+  description = "ID of the Security Hub V2 AWS Organizations policy"
 
-output "guardduty_organization_features" {
-  description = "GuardDuty organization protection-plan auto-enablement configuration."
-
-  value = {
-    for feature_name, feature in aws_guardduty_organization_configuration_feature.main :
-    feature_name => {
-      auto_enable = feature.auto_enable
-    }
-  }
+  value = try(
+    aws_organizations_policy.securityhub_v2_workloads[0].id,
+    null
+  )
 }

--- a/bootstrap/security_operations/security_services/terraform.tfvars.example
+++ b/bootstrap/security_operations/security_services/terraform.tfvars.example
@@ -1,21 +1,92 @@
+# Required stack configuration
+
+cloud_name     = "tf-secure-baseline"
+environment    = "security-operations"
+primary_region = "us-east-1"
+account_id     = "123456789012"
+
+
+# Security Hub CSPM central organization configuration
+
+enable_securityhub_organization_configuration = true
+
 securityhub_cspm_account_policies = {
   dev = {
     create_policy    = true
     associate_policy = true
-    enabled_standard_keys = [
+
+    enabled_standards = [
       "aws_fsbp",
-      "cis_5_0"
+      "cis_5_0",
     ]
+
     disabled_control_identifiers = []
   }
 
   staging = {
     create_policy    = true
     associate_policy = true
-    enabled_standard_keys = [
+
+    enabled_standards = [
       "aws_fsbp",
-      "cis_5_0"
+      "cis_5_0",
     ]
+
+    disabled_control_identifiers = []
+  }
+
+  prod = {
+    create_policy    = true
+    associate_policy = true
+
+    enabled_standards = [
+      "aws_fsbp",
+      "cis_5_0",
+    ]
+
     disabled_control_identifiers = []
   }
 }
+
+
+# GuardDuty central organization configuration
+
+enable_guardduty_organization_configuration = true
+
+guardduty_organization_features = {
+  S3_DATA_EVENTS = {
+    auto_enable = "ALL"
+  }
+
+  EBS_MALWARE_PROTECTION = {
+    auto_enable = "ALL"
+  }
+
+  LAMBDA_NETWORK_LOGS = {
+    auto_enable = "ALL"
+  }
+
+  RUNTIME_MONITORING = {
+    auto_enable = "ALL"
+
+    additional_configuration = [
+      {
+        name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+        auto_enable = "NONE"
+      },
+      {
+        name        = "EC2_AGENT_MANAGEMENT"
+        auto_enable = "ALL"
+      },
+      {
+        name        = "EKS_ADDON_MANAGEMENT"
+        auto_enable = "NONE"
+      },
+    ]
+  }
+}
+
+
+# Security Hub V2 organization policy
+
+enable_securityhub_v2_organization_policy = true

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -102,8 +102,11 @@ variable "guardduty_organization_features" {
   type = map(object({
     auto_enable = optional(string, "ALL")
 
-    additional_configuration = optional(map(string), {})
-  }))
+    additional_configuration = optional(list(object({
+        name        = string
+        auto_enable = string
+    })), [])
+    }))
 
   default = {
     S3_DATA_EVENTS = {
@@ -121,9 +124,20 @@ variable "guardduty_organization_features" {
     RUNTIME_MONITORING = {
       auto_enable = "ALL"
 
-      additional_configuration = {
-        EC2_AGENT_MANAGEMENT = "ALL"
-      }
+      additional_configuration = [
+        {
+            name = "ECS_FARGATE_AGENT_MANAGEMENT"
+            auto_enable = "NONE"
+        },
+        {
+            name = "EC2_AGENT_MANAGEMENT"
+            auto_enable = "ALL"
+        },
+        {
+            name = "EKS_ADDON_MANAGEMENT"
+            auto_enable = "NONE"
+        }
+      ]
     }
   }
 
@@ -138,12 +152,33 @@ variable "guardduty_organization_features" {
 
   validation {
     condition = alltrue(flatten([
-      for feature in values(var.guardduty_organization_features) : [
-        for value in values(feature.additional_configuration) :
-        contains(["ALL", "NEW", "NONE"], value)
-      ]
+        for feature in values(var.guardduty_organization_features) : [
+        for configuration in feature.additional_configuration :
+        contains(
+            ["ALL", "NEW", "NONE"],
+            configuration.auto_enable
+        )
+        ]
     ]))
 
     error_message = "GuardDuty additional configuration values must be ALL, NEW, or NONE."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+        for feature in values(var.guardduty_organization_features) : [
+        for configuration in feature.additional_configuration :
+        contains(
+            [
+            "ECS_FARGATE_AGENT_MANAGEMENT",
+            "EC2_AGENT_MANAGEMENT",
+            "EKS_ADDON_MANAGEMENT",
+            ],
+            configuration.name
+        )
+        ]
+    ]))
+
+    error_message = "GuardDuty additional configuration contains an unsupported name."
   }
 }

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -188,3 +188,9 @@ variable "guardduty_organization_features" {
     error_message = "GuardDuty additional configuration contains an unsupported name."
   }
 }
+
+variable "enable_securityhub_v2_organization_policy" {
+  description = "Enable the Security Hub V2 AWS Organizations policy and attach it to workload accounts"
+  type        = bool
+  default     = false
+}

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -144,6 +144,6 @@ variable "guardduty_organization_features" {
       ]
     ]))
 
-    error_message = "GuardDuty additional confiruation values must be ALL, NEW, or NONE."
+    error_message = "GuardDuty additional configuration values must be ALL, NEW, or NONE."
   }
 }

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -96,6 +96,12 @@ variable "securityhub_cspm_account_policies" {
   }
 }
 
+variable "enable_guardduty_organization_configuration" {
+  description = "Enable GuardDuty organization-wide member and protection-plan configuration after delegated administration is configured"
+  type        = bool
+  default     = false
+}
+
 variable "guardduty_organization_features" {
   description = "GuardDuty protection plans centrally-managed across the AWS organization."
 

--- a/bootstrap/security_operations/security_services/variables.tf
+++ b/bootstrap/security_operations/security_services/variables.tf
@@ -103,10 +103,10 @@ variable "guardduty_organization_features" {
     auto_enable = optional(string, "ALL")
 
     additional_configuration = optional(list(object({
-        name        = string
-        auto_enable = string
+      name        = string
+      auto_enable = string
     })), [])
-    }))
+  }))
 
   default = {
     S3_DATA_EVENTS = {
@@ -126,16 +126,16 @@ variable "guardduty_organization_features" {
 
       additional_configuration = [
         {
-            name = "ECS_FARGATE_AGENT_MANAGEMENT"
-            auto_enable = "NONE"
+          name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+          auto_enable = "NONE"
         },
         {
-            name = "EC2_AGENT_MANAGEMENT"
-            auto_enable = "ALL"
+          name        = "EC2_AGENT_MANAGEMENT"
+          auto_enable = "ALL"
         },
         {
-            name = "EKS_ADDON_MANAGEMENT"
-            auto_enable = "NONE"
+          name        = "EKS_ADDON_MANAGEMENT"
+          auto_enable = "NONE"
         }
       ]
     }
@@ -152,13 +152,13 @@ variable "guardduty_organization_features" {
 
   validation {
     condition = alltrue(flatten([
-        for feature in values(var.guardduty_organization_features) : [
+      for feature in values(var.guardduty_organization_features) : [
         for configuration in feature.additional_configuration :
         contains(
-            ["ALL", "NEW", "NONE"],
-            configuration.auto_enable
+          ["ALL", "NEW", "NONE"],
+          configuration.auto_enable
         )
-        ]
+      ]
     ]))
 
     error_message = "GuardDuty additional configuration values must be ALL, NEW, or NONE."
@@ -166,17 +166,17 @@ variable "guardduty_organization_features" {
 
   validation {
     condition = alltrue(flatten([
-        for feature in values(var.guardduty_organization_features) : [
+      for feature in values(var.guardduty_organization_features) : [
         for configuration in feature.additional_configuration :
         contains(
-            [
+          [
             "ECS_FARGATE_AGENT_MANAGEMENT",
             "EC2_AGENT_MANAGEMENT",
             "EKS_ADDON_MANAGEMENT",
-            ],
-            configuration.name
+          ],
+          configuration.name
         )
-        ]
+      ]
     ]))
 
     error_message = "GuardDuty additional configuration contains an unsupported name."

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -23,4 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
+  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
 }

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -23,5 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
-  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
+  manage_securityhub_v2_locally      = var.manage_securityhub_v2_locally
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -160,6 +160,12 @@ variable "manage_securityhub_cspm_locally" {
   default     = false
 }
 
+variable "manage_securityhub_v2_locally" {
+  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  type = bool
+  default = false
+}
+
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -161,7 +161,7 @@ variable "manage_securityhub_cspm_locally" {
 }
 
 variable "manage_securityhub_v2_locally" {
-  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  description = "Whether Security Hub V2 is managed locally instead of through centralized organization policy"
   type        = bool
   default     = false
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -162,8 +162,8 @@ variable "manage_securityhub_cspm_locally" {
 
 variable "manage_securityhub_v2_locally" {
   description = "Whether this workload account manages Security Hub V2 directly in the workload account"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "manage_guardduty_locally" {

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -23,4 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
+  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -23,5 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
-  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
+  manage_securityhub_v2_locally      = var.manage_securityhub_v2_locally
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -160,6 +160,12 @@ variable "manage_securityhub_cspm_locally" {
   default     = false
 }
 
+variable "manage_securityhub_v2_locally" {
+  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  type = bool
+  default = false
+}
+
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -161,7 +161,7 @@ variable "manage_securityhub_cspm_locally" {
 }
 
 variable "manage_securityhub_v2_locally" {
-  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  description = "Whether Security Hub V2 is managed locally instead of through centralized organization policy"
   type        = bool
   default     = false
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -162,8 +162,8 @@ variable "manage_securityhub_cspm_locally" {
 
 variable "manage_securityhub_v2_locally" {
   description = "Whether this workload account manages Security Hub V2 directly in the workload account"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "manage_guardduty_locally" {

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -23,4 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
+  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
 }

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -23,5 +23,5 @@ module "baseline" {
   isolation_allowed                  = var.isolation_allowed
   manage_securityhub_cspm_locally    = var.manage_securityhub_cspm_locally
   manage_guardduty_locally           = var.manage_guardduty_locally
-  manage_securityhub_v2_locally = var.manage_securityhub_v2_locally
+  manage_securityhub_v2_locally      = var.manage_securityhub_v2_locally
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -160,6 +160,12 @@ variable "manage_securityhub_cspm_locally" {
   default     = false
 }
 
+variable "manage_securityhub_v2_locally" {
+  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  type = bool
+  default = false
+}
+
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -161,7 +161,7 @@ variable "manage_securityhub_cspm_locally" {
 }
 
 variable "manage_securityhub_v2_locally" {
-  description = "Whether this workload account manages Security Hub V2 directly in the workload account"
+  description = "Whether Security Hub V2 is managed locally instead of through centralized organization policy"
   type        = bool
   default     = false
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -162,8 +162,8 @@ variable "manage_securityhub_cspm_locally" {
 
 variable "manage_securityhub_v2_locally" {
   description = "Whether this workload account manages Security Hub V2 directly in the workload account"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "manage_guardduty_locally" {

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -55,9 +55,7 @@ resource "aws_securityhub_account" "main" {
 }
 
 resource "aws_securityhub_account_v2" "main" {
-  depends_on = [
-    aws_securityhub_account.main
-  ]
+  count = var.manage_securityhub_v2_locally ? 1 : 0
 }
 
 ## SUBSCRIBE TO EACH SECURITY HUB STANDARD LISTED IN 'local.securityhub_standards'

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -103,6 +103,12 @@ variable "manage_securityhub_cspm_locally" {
   default     = true
 }
 
+variable "manage_securityhub_v2_locally" {
+  description = "Whether this module manages Security Hub V2 directly in the workload account"
+  type        = bool
+  default     = true
+}
+
 variable "manage_guardduty_locally" {
   description = "Whether this workload account manages its own GuardDuty detector and detector features. Set to false when GuardDuty is centrally managed from the security-operations account."
   type        = bool


### PR DESCRIPTION
Closes #662 - Centralize Security Hub v2
Closes #664 - Create README.md file for the `./bootstrap/security_operations/security_services/` stack
Closes #667 - Update `bootstrap/security_operations/security_services/terraform.tfvars.example`