### PR TITLE
fix: guardduty-data VPC endpoint bug causing `validate-vpc-endpoints.sh` script to fail all envs

### DIFF
--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -241,10 +241,6 @@ module "vpc_endpoints" {
   )
 
   subnet_cidrs  = var.subnet_cidrs
-  compute_sg_id = module.compute.compute_sg_id
-
-  lambda_ec2_isolation_sg_id = module.automation.lambda_ec2_isolation_sg_id
-  lambda_ec2_rollback_sg_id  = module.automation.lambda_ec2_rollback_sg_id
 }
 
 module "firewall" {

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -58,6 +58,7 @@ module "compute" {
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed
 
+  interface_endpoint_ids = module.vpc_endpoints.interface_endpoint_ids
   interface_endpoints_sg_id = module.vpc_endpoints.interface_endpoints_sg_id
   data_sg_id                = module.storage.data_sg_id
   db_port                   = var.db_port

--- a/baseline/main.tf
+++ b/baseline/main.tf
@@ -58,7 +58,7 @@ module "compute" {
   ebs_cmk_arn                    = module.security.ebs_cmk_arn
   isolation_allowed              = var.isolation_allowed
 
-  interface_endpoint_ids = module.vpc_endpoints.interface_endpoint_ids
+  interface_endpoint_ids    = module.vpc_endpoints.interface_endpoint_ids
   interface_endpoints_sg_id = module.vpc_endpoints.interface_endpoints_sg_id
   data_sg_id                = module.storage.data_sg_id
   db_port                   = var.db_port
@@ -241,7 +241,7 @@ module "vpc_endpoints" {
     values(module.networking.serverless_private_route_table_ids_map)
   )
 
-  subnet_cidrs  = var.subnet_cidrs
+  subnet_cidrs = var.subnet_cidrs
 }
 
 module "firewall" {

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -52,6 +52,11 @@ resource "terraform_data" "compute_security_policy_ready" {
   input = var.compute_sg_rule_ids
 }
 
+## Interface VPC Endpoint IDs that must exist before compute instances launch
+resource "terraform_data" "compute_vpc_endpoints_ready" {
+  input = var.interface_endpoint_ids
+}
+
 ## EC2 INSTANCE
 resource "aws_instance" "ec2" {
   for_each               = var.compute_private_subnet_ids_map
@@ -90,7 +95,8 @@ resource "aws_instance" "ec2" {
   }
 
   depends_on = [
-    terraform_data.compute_security_policy_ready
+    terraform_data.compute_security_policy_ready,
+    terraform_data.compute_vpc_endpoints_ready
   ]
 
   tags = {

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -54,3 +54,8 @@ variable "compute_sg_rule_ids" {
     compute_egress_to_internet_https = optional(string)
   })
 }
+
+variable "interface_endpoint_ids" {
+  description = "Map of Interface-type VPC Endpoints and their IDs"
+  type = map(string)
+}

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -57,5 +57,5 @@ variable "compute_sg_rule_ids" {
 
 variable "interface_endpoint_ids" {
   description = "Map of Interface-type VPC Endpoints and their IDs"
-  type = map(string)
+  type        = map(string)
 }

--- a/modules/vpc_endpoints/main.tf
+++ b/modules/vpc_endpoints/main.tf
@@ -18,7 +18,8 @@ locals {
     "ec2",
     "events",
     "securityhub",
-    "lambda"
+    "lambda",
+    "guardduty-data",
   ]
 }
 

--- a/modules/vpc_endpoints/outputs.tf
+++ b/modules/vpc_endpoints/outputs.tf
@@ -1,3 +1,10 @@
 output "interface_endpoints_sg_id" {
   value = aws_security_group.interface_endpoints_sg.id
 }
+
+output "interface_endpoint_ids" {
+  value = {
+    for service, endpoint in aws_vpc_endpoint.interface :
+    service => endpoint.id
+  }
+}

--- a/modules/vpc_endpoints/variables.tf
+++ b/modules/vpc_endpoints/variables.tf
@@ -35,18 +35,6 @@ variable "subnet_cidrs" {
   type = map(list(string))
 }
 
-variable "compute_sg_id" {
-  type = string
-}
-
-variable "lambda_ec2_isolation_sg_id" {
-  type = string
-}
-
-variable "lambda_ec2_rollback_sg_id" {
-  type = string
-}
-
 variable "endpoint_private_route_table_ids_map" {
   description = "map(string) of Endpoint Private Route Table IDs"
   type        = map(string)


### PR DESCRIPTION
Closes #676 - Fix issue where centralized GuardDuty is automatically creating a `guardduty-data` VPC endpoint, causing the `validate-vpc-endpoints.sh` script to fail