### PR TITLE
fix: json syntax errors in `export-baseline.sh`, `export-bootstrap.sh`, and `export-control-plane.sh`

### DIFF
--- a/scripts/validation/export-baseline.sh
+++ b/scripts/validation/export-baseline.sh
@@ -220,7 +220,7 @@ jq -n \
       {
         "validation": "end_user_sso_login_validation",
         "workflow: null
-      }
+      },
       {
         "validation": "live_ec2_isolation",
         "workflow": null

--- a/scripts/validation/export-bootstrap.sh
+++ b/scripts/validation/export-bootstrap.sh
@@ -287,7 +287,7 @@ jq -n \
       {
         "validation": "end_user_sso_login_validation",
         "workflow: null
-      }
+      },
       {
         "validation": "live_ec2_isolation",
         "workflow": null

--- a/scripts/validation/export-control-plane.sh
+++ b/scripts/validation/export-control-plane.sh
@@ -362,7 +362,7 @@ jq -n \
       {
         "validation": "end_user_sso_login_validation",
         "workflow: null
-      }
+      },
       {
         "validation": "live_ec2_isolation",
         "workflow": null


### PR DESCRIPTION
Closes #678 - Fix json syntax errors in `export-baseline.sh`, `export-bootstrap.sh`, and `export-control-plane.sh`