### PR TITLE
ci: add `bootstrap/security_operations/security_services` stack to `Terraform Plan` CI/CD workflow

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -70,6 +70,7 @@ jobs:
       TF_VAR_break_glass_trusted_principal_arns: ${{ vars.BREAK_GLASS_TRUSTED_PRINCIPAL_ARNS }}
       TF_VAR_secops_emails: ${{ vars.SECOPS_EMAILS }}
       TF_VAR_isolation_allowed: ${{ vars.ISOLATION_ALLOWED }}
+      TF_VAR_account_id: ${{ vars.ACCOUNT_ID }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,6 +47,9 @@ jobs:
           - environment: control-plane-organizations
             github_environment: control-plane-plan
             working_directory: ./bootstrap/control_plane/organizations
+          - environment: security-operations-security-services
+            github_environment: security-operations-plan
+            working_directory: ./bootstrap/security_operations/security_services
 
     concurrency:
       group: terraform-plan-${{ github.head_ref || github.ref_name }}-${{ matrix.environment }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -71,6 +71,10 @@ jobs:
       TF_VAR_secops_emails: ${{ vars.SECOPS_EMAILS }}
       TF_VAR_isolation_allowed: ${{ vars.ISOLATION_ALLOWED }}
       TF_VAR_account_id: ${{ vars.ACCOUNT_ID }}
+      TF_VAR_enable_securityhub_organization_configuration: ${{ vars.ENABLE_SECURITYHUB_ORGANIZATION_CONFIGURATION }}
+      TF_VAR_securityhub_cspm_account_policies: ${{ vars.SECURITYHUB_CSPM_ACCOUNT_POLICIES }}
+      TF_VAR_enable_guardduty_organization_configuration: ${{ vars.ENABLE_GUARDDUTY_ORGANIZATION_CONFIGURATION }}
+      TF_VAR_enable_securityhub_v2_organization_policy: ${{ vars.ENABLE_SECURITYHUB_V2_ORGANIZATION_POLICY }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -14,6 +14,7 @@ on:
           - prod
           - control-plane-identity-center
           - control-plane-organizations
+          - security-operations-security-services
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Closes #684 - Add `bootstrap/security_operations/security_services` stack to `Terraform Plan` CI/CD workflow